### PR TITLE
Rough improvements to the validation script

### DIFF
--- a/scripts/json_schema_validator.pl
+++ b/scripts/json_schema_validator.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use JSON;
 use Data::Dumper;
@@ -9,8 +9,8 @@ my $schema = $ARGV[1];
 
 my $validator = JSON::Validator->new;
 $validator->schema($schema);
-my $count = 0;
-
+my $line_count = 1;
+my $err_count = 0;
 open(FILE, "<$json");
 
 while(<FILE>){
@@ -20,11 +20,12 @@ while(<FILE>){
    my @errors = $validator->validate(from_json($line));
 
    if(@errors){
-      print Dumper $_ foreach @errors;
-    }
-   else {
-     $count++;
+      warn "Error on line $line_count : \t";
+      warn Dumper $_ foreach @errors;
+      $err_count++;	
    }
+   $line_count++;
 }
-
-print "$count evidence(s) PASSED schema validation !\n" if($count >0);
+if($err_count>0){
+   die "Exited with $err_count errors"
+}


### PR DESCRIPTION
More portable shebang - use user's perl instead of OS's perl. 
Print line numbers when validating.
Print error messages to stderr, and fail with nonzero exit code when errors found.