### PR TITLE
update regex to fix variant_id pattern error

### DIFF
--- a/src/bioentity/variant.json
+++ b/src/bioentity/variant.json
@@ -13,7 +13,7 @@
                 "id": {
                     "type": "string",
                     "description": "An array of variant identifiers",
-		    "pattern": "^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}|http://identifiers.org/dbsnp/rs[0-9]{1,})| http://identifiers.org/dbsnp/esv[0-9]{1,})|http://identifiers.org/dbsnp/nsv[0-9]{1,}$)"
+		    "pattern": "^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}|http://identifiers.org/dbsnp/rs[0-9]{1,})|http://identifiers.org/dbsnp/esv[0-9]{1,})|http://identifiers.org/dbsnp/nsv[0-9]{1,}$)"
                 },
                 "type": {
                     "type": "string",

--- a/src/bioentity/variant.json
+++ b/src/bioentity/variant.json
@@ -13,7 +13,7 @@
                 "id": {
                     "type": "string",
                     "description": "An array of variant identifiers",
-                    "pattern": "(^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}$)|(^http://identifiers.org/dbsnp/rs[0-9]+$)|(^http://identifiers.org/dbsnp/esv[0-9]+$)|(^http://identifiers.org/dbsnp/nsv[0-9]+$)"
+		    "pattern": "^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}|http://identifiers.org/dbsnp/rs[0-9]{1,})| http://identifiers.org/dbsnp/esv[0-9]{1,})|http://identifiers.org/dbsnp/nsv[0-9]{1,}$)"
                 },
                 "type": {
                     "type": "string",

--- a/src/bioentity/variant.json
+++ b/src/bioentity/variant.json
@@ -13,7 +13,7 @@
                 "id": {
                     "type": "string",
                     "description": "An array of variant identifiers",
-                    "pattern": "(^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}$)|(^http://identifiers.org/dbsnp/rs[0-9]+$|esv[0-9]+$|nsv[0-9]+$)"
+                    "pattern": "(^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}$)|(^http://identifiers.org/dbsnp/rs[0-9]+$)|(^http://identifiers.org/dbsnp/esv[0-9]+$)|(^http://identifiers.org/dbsnp/nsv[0-9]+$)"
                 },
                 "type": {
                     "type": "string",


### PR DESCRIPTION
This should fix the 

ERROR - Variant - root.variant.id 'http://identifiers.org/dbsnp/nsv1067874' does not match pattern '(^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}$)|(^http://identifiers.org/dbsnp/rs[0-9]+$%7Cesv[0-9]+$%7Cnsv[0-9]+$)'

in EVA