### PR TITLE
add new ECO code for genetics.json

### DIFF
--- a/src/evidence/genetics/gene2variant.json
+++ b/src/evidence/genetics/gene2variant.json
@@ -20,7 +20,8 @@
             "type": "string",
             "enum": [
               "http://identifiers.org/eco/cttv_mapping_pipeline",
-              "http://purl.obolibrary.org/obo/ECO_0000205"
+              "http://purl.obolibrary.org/obo/ECO_0000205",
+              "http://purl.obolibrary.org/obo/ECO_0000305"
             ]
           },
           "minItems": 1


### PR DESCRIPTION
@gkos-bio uniprot has evidence with the ECO code currently not in gene2variant.json. Added
http://purl.obolibrary.org/obo/ECO_0000305. 

Please merge back to master. 