### PR TITLE
add field to capture clinical_significance from clinvar

### DIFF
--- a/src/evidence/genetics/variant2disease.json
+++ b/src/evidence/genetics/variant2disease.json
@@ -13,6 +13,14 @@
         "allOf": {
           "$ref": "https://raw.githubusercontent.com/opentargets/json_schema/master/src/evidence/base.json"
         },
+        "clinical_significance": {
+          "type": "string",
+	  "enum": [
+              "Pathogenic" ,
+              "Likely pathogenic" ,
+	      "protective"
+          ]
+        },
         "gwas_panel_resolution": {
           "description": "Panel resolution of GWAS study",
           "type": "number",

--- a/src/evidence/genetics/variant2disease.json
+++ b/src/evidence/genetics/variant2disease.json
@@ -56,6 +56,7 @@
     }
   ],
   "properties": {
+    "clinical_significance": {},
     "resource_score": {},
     "unique_experiment_reference": {},
     "provenance_type": {},


### PR DESCRIPTION
@iandunham  
@gkos-bio  this is the schema change to add "protective" variants from clinvar, please merge if you see no issues. for details,
https://github.com/opentargets/data-providers-docs/issues/24