### PR TITLE
update minItems for literature as some COSMIC data will not all have PMID id

### DIFF
--- a/src/evidence/base.json
+++ b/src/evidence/base.json
@@ -79,7 +79,7 @@
                 "type": "object",
                 "$ref": "#/definitions/single_lit_reference"
               },
-              "minItems": 1,
+              "minItems": 0,
               "uniqueItems": true
             }
           },


### PR DESCRIPTION
Allowing empty literature object for COSMIC as their provenance can be e.g.:

provenance_type":{"database":{"version":"81","id":"Cosmic","dbxref":{"version":"81","url":"http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=670","id":"670"}}

which is one of the big whole-genome studies processed by COSMIC curators. It wasn’t published as a paper, hence no PubmedIDs for it. For some mutations, there are both PMID and ID study, for some of them just one of these. 