### PR TITLE
reintroduce minItems=1 for literature_reference

### DIFF
--- a/src/evidence/base.json
+++ b/src/evidence/base.json
@@ -79,7 +79,7 @@
                 "type": "object",
                 "$ref": "#/definitions/single_lit_reference"
               },
-              "minItems": 0,
+              "minItems": 1,
               "uniqueItems": true
             }
           },


### PR DESCRIPTION
It would be better for data provider to remove empty `"literature":{"references":[]}` then for us to change the schema