### PR TITLE
validated_against_schema_version relaxed to >1.2

### DIFF
--- a/src/base.json
+++ b/src/base.json
@@ -23,9 +23,7 @@
     "validated_against_schema_version": {
       "description": "The OpenTargets-JSON schema version number against which your data was validated",
       "type": "string",
-      "enum": [
-        "1.2.8"
-      ]
+      "pattern": "^([1]+).([2-9]+).([0-9]+)$"
     },
 
     "unique_association_fields": {


### PR DESCRIPTION
I have relaxed the constraint on `validated_Against_Schema_version`. 
Now it will fail only if the version number is < 1.2.x

