### PR TITLE
Support consequence type 5_prime_UTR_variant

### DIFF
--- a/src/evidence/mutation/mutation.json
+++ b/src/evidence/mutation/mutation.json
@@ -54,7 +54,8 @@
         "http://purl.obolibrary.org/obo/SO_0002012",
         "http://purl.obolibrary.org/obo/SO_0001627",
         "http://purl.obolibrary.org/obo/SO_0001060",
-        "http://purl.obolibrary.org/obo/SO_0001624"
+        "http://purl.obolibrary.org/obo/SO_0001624",
+        "http://purl.obolibrary.org/obo/SO_0001623"
       ]
     },
     "number_samples_tested": {


### PR DESCRIPTION
The consequence type of some ClinVar records is 5_prime_UTR_variant, but according to [the current version of the JSON schema](https://github.com/opentargets/json_schema/blob/df1006427ca99ac360e5ac618ae696f4bb1ed78f/src/evidence/mutation/mutation.json#L25-L59) this is not an accepted value. This PR adds support for this consequence type.