### PR TITLE
have travis recursively check all json files in src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,4 @@ install:
   - pip install git+git://github.com/Julian/jsonschema.git@v3.0.0a3#egg=jsonschema
   - wget -O draft7.json http://json-schema.org/draft-07/schema
 script:
-  - jsonschema -i src/animal_models.json draft7.json
-  - jsonschema -i src/drug.json draft7.json
-  - jsonschema -i src/expression.json draft7.json
-  - jsonschema -i src/genetics.json draft7.json
-  - jsonschema -i src/literature_curated.json draft7.json
-  - jsonschema -i src/literature_mining.json draft7.json
+  - find src -name "*.json" -exec jsonschema -i {} draft7.json \;


### PR DESCRIPTION
Change the validation of json file to recursively check everything within the src file. This is better than not checking all json files, but still doesn't check that relative reference are actually working correctly.