### PR TITLE
Upgrade DOI regex for preferred resolver variant

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -946,7 +946,7 @@
         "lit_id": {
           "type": "string",
           "description": "Note for pubmed identifiers, use the URI http://europepmc.org/abstract/MED/[0-9]+",
-          "pattern": "NA|http://europepmc.org/abstract/MED/[0-9]+|http://europepmc.org/articles/PMC[0-9]{4,}|[doi|DOI|https://dx.doi.org/]*[\u005Cs\u005C.\u005C:]{0,2}(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![\u005C\"&\u005C'])\u005CS)+)$"
+          "pattern": "NA|http://europepmc.org/abstract/MED/[0-9]+|http://europepmc.org/articles/PMC[0-9]{4,}|[doi|DOI|(https?://)?(dx\.)?doi.org/]*[\u005Cs\u005C.\u005C:]{0,2}(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![\u005C\"&\u005C'])\u005CS)+)$"
         },
         "rank": {
           "type": "object",


### PR DESCRIPTION
See diff & https://www.doi.org/doi_handbook/3_Resolution.html#3.8 ;-)

Also, [Crossref suggests another pattern](https://www.crossref.org/blog/dois-and-matching-regular-expressions/) to match the DOIs themselves. I hope this proves useful to you in the continued development of OpenTargets.

Cheers!