### PR TITLE
changes to activity values for chembl

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -389,29 +389,6 @@
             "molecule_type": {
               "type": "string"
             },
-            "max_phase_for_all_diseases": {
-              "type": "object",
-              "$ref": "#/definitions/diseasephase"
-            },
-            "withdrawn_country": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "withdrawn_reason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "withdrawn_year": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
           "required": [
             "id",
             "molecule_name",

--- a/opentargets.json
+++ b/opentargets.json
@@ -388,7 +388,8 @@
             },
             "molecule_type": {
               "type": "string"
-            },
+            }
+          },
           "required": [
             "id",
             "molecule_name",

--- a/opentargets.json
+++ b/opentargets.json
@@ -70,8 +70,9 @@
           "enum": [
             "http://identifiers.org/cttv.activity/decreased_transcript_level",
             "http://identifiers.org/cttv.activity/decreased_translational_product_level",
-            "http://identifiers.org/cttv.activity/drug_negative_modulator",
-            "http://identifiers.org/cttv.activity/drug_positive_modulator",
+            "http://identifiers.org/cttv.activity/negative_modulator",
+            "http://identifiers.org/cttv.activity/positive_modulator",
+            "http://identifiers.org/cttv.activity/other",
             "http://identifiers.org/cttv.activity/gain_of_function",
             "http://identifiers.org/cttv.activity/increased_transcript_level",
             "http://identifiers.org/cttv.activity/increased_translational_product_level",


### PR DESCRIPTION
Changed             
`http://identifiers.org/cttv.activity/drug_negative_modulator`
`http://identifiers.org/cttv.activity/drug_positive_modulator`
to 
`http://identifiers.org/cttv.activity/negative_modulator`
`http://identifiers.org/cttv.activity/positive_modulator`
and added: 
`http://identifiers.org/cttv.activity/other`

I checked that `drug_negative_regulator` and `drug_positive_modulator` are not used by any other datasource.

This PR is related to this ticket: [#533](https://github.com/opentargets/platform/issues/533)
