### PR TITLE
Ag genetic association fix

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -268,7 +268,8 @@
             "experiment_overview",
             "test_replicates_n",
             "reference_replicates_n",
-            "confidence_level"
+            "confidence_level",
+            "resource_score"
           ]
         }
       },
@@ -489,7 +490,10 @@
                   },
                   "uniqueItems": true
                 }
-              }
+              },
+              "required":[
+                "resource_score"
+              ]
             },
             "biological_model": {
               "type": "object",
@@ -636,7 +640,10 @@
                   },
                   "uniqueItems": true
                 }
-              }
+              },
+              "required": [
+                "resource_score"
+              ]
             }
           },
           "required": [
@@ -676,7 +683,10 @@
               "type": "object",
               "$ref": "#/definitions/single_lit_reference"
             }
-          }
+          },
+          "required": [
+            "resource_score"
+          ]
         }
       },
       "required": [
@@ -932,7 +942,8 @@
             }
           },
           "required": [
-            "evidence_codes"
+            "evidence_codes",
+            "resource_score"
           ]
         }
       },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1305,7 +1305,6 @@
         }
       },
       "required": [
-        "resource_score",
         "provenance_type",
         "is_associated",
         "date_asserted"


### PR DESCRIPTION
This PR fixes the issues caused after PR #74 was merged. The changes made in that PR did not break anything per se, instead, an issue that had gone unnoticed since the JSON schema was consolidated in a single file in version 1.4.0 surfaced.
Basically, since the consolidation `resource_score` was required in `evidence_base` which makes all `genetic_association` evidence invalid because the `gene2variant` part does not have an score. This PR removes the requirement from `evidence_base` and adds it directly to all the evidence that have an score and that did not require it explicitly.