### PR TITLE
Add mantissa and exponent format to p-value and require value

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1030,11 +1030,22 @@
           "maximum": 1,
           "exclusiveMinimum": 0
         },
+        "mantissa": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "exponent": {
+          "type": "number",
+          "maximum": 0
+        },
         "method": {
           "type": "object",
           "$ref": "#/definitions/score_method"
         }
-      }
+      },
+      "required": [
+        "value"
+      ]
     },
     "score_probability": {
       "type": "object",


### PR DESCRIPTION
In order to avoid issues with small p-values being rounded to zero (https://github.com/opentargets/platform/issues/434), they will also be accepted as mantissa and exponent. However, floating-point notation will be required until changes are made to the pipeline.