### PR TITLE
Draft-7 compatible modifications to accommodate Genetics portal eviden…

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1056,7 +1056,8 @@
         "type": {
           "type": "string",
           "enum": [
-            "probability"
+            "probability",
+            "locus_to_gene_score"
           ]
         },
         "value": {
@@ -1123,29 +1124,6 @@
         "position",
         "sample_size",
         "type"
-      ]
-    },
-    "score_locus_to_gene": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "locus_to_gene_score"
-          ]
-        },
-        "value": {
-          "type": "number",
-          "maximum": 1,
-          "exclusiveMinimum": 0
-        },
-        "method": {
-          "type": "object",
-          "$ref": "#/definitions/score_method"
-        }
-      },
-      "required": [
-        "value"
       ]
     },
     "linkout": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -684,14 +684,17 @@
             "id": {
               "type": "string",
               "description": "An array of variant identifiers",
-              "pattern": "^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}|http://identifiers.org/dbsnp/rs[0-9]{1,}|http://identifiers.org/dbsnp/esv[0-9]{1,}|http://identifiers.org/dbsnp/nsv[0-9]{1,}$"
+              "pattern": "^http://www.ncbi.nlm.nih.gov/clinvar/RCV[0-9]{9}|http://identifiers.org/dbsnp/rs[0-9]{1,}|http://identifiers.org/dbsnp/esv[0-9]{1,}|http://identifiers.org/dbsnp/nsv[0-9]{1,}|.{,2}_[0-9]+_[ACTG]+_[ACTG]+$"
             },
             "type": {
               "type": "string",
               "enum": [
                 "snp single",
                 "snp snp interaction",
-                "structural variant"
+                "structural variant",
+                "SNP",
+                "deletion",
+                "insertion"
               ]
             }
           },
@@ -1122,6 +1125,29 @@
         "type"
       ]
     },
+    "score_locus_to_gene": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "locus_to_gene_score"
+          ]
+        },
+        "value": {
+          "type": "number",
+          "maximum": 1,
+          "exclusiveMinimum": 0
+        },
+        "method": {
+          "type": "object",
+          "$ref": "#/definitions/score_method"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
     "linkout": {
       "type": "object",
       "properties": {
@@ -1214,7 +1240,10 @@
             },
             {
               "$ref": "#/definitions/score_summed_total"
-            }
+            },
+            {
+              "$ref": "#/definitions/score_locus_to_gene"
+            } 
           ]
         },
         "provenance_type": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1218,9 +1218,6 @@
             },
             {
               "$ref": "#/definitions/score_summed_total"
-            },
-            {
-              "$ref": "#/definitions/score_locus_to_gene"
             } 
           ]
         },


### PR DESCRIPTION
Draft-7 compatible modifications to accommodate Genetics portal evidences.

* The variant ID pattern is extended to support variant IDs  without rsIDs.
* Evidence score is provided as L2G score in `.evidence.gene2variant.resource_score`
* List of supported variant types are extended.