### PR TITLE
Ag no missing disease

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -118,7 +118,8 @@
           "type": "string",
           "description": "A valid EFO full IRI",
           "pattern": "^[^\u0020]*$",
-          "minLength": 1
+          "minLength": 1,
+          "format": "uri"
         },
         "name": {
           "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -117,7 +117,8 @@
         "id": {
           "type": "string",
           "description": "A valid EFO full IRI",
-          "pattern": "^[^\u0020]*$"
+          "pattern": "^[^\u0020]*$",
+          "minLength": 1
         },
         "name": {
           "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -116,7 +116,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "A valid EFO full IRI"
+          "description": "A valid EFO full IRI",
+          "pattern": "^[^\u0020]*$"
         },
         "name": {
           "type": "string",


### PR DESCRIPTION
Invalidates empty disease ids (see issue [#860](https://github.com/opentargets/platform/issues/860))