### PR TITLE
Accept 'N/A' in date_asserted for missing values

### DIFF
--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -1251,8 +1251,8 @@
         },
         "date_asserted": {
           "type": "string",
-          "description": "date the evidence was made public in yyyy-mm-dd format",
-          "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+          "description": "date the evidence was made public in yyyy-mm-dd format or N/A if not available",
+          "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])|N/A"
         },
         "resource_score": {
           "type": "object",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1236,8 +1236,8 @@
         },
         "date_asserted": {
           "type": "string",
-          "description": "date the evidence was made public in yyyy-mm-dd format",
-          "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+          "description": "date the evidence was made public in yyyy-mm-dd format or N/A if not available",
+          "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])|N/A"
         },
         "resource_score": {
           "type": "object",


### PR DESCRIPTION
In a conversation with @d0choa and @iandunham it was decided that "N/A" is an acceptable value for the `date_asserted` when the real date is missing