### PR TITLE
Adjust enum of clinical significance values

### DIFF
--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -791,27 +791,7 @@
                     },
                     {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "pathogenic",
-                          "likely pathogenic",
-                          "protective",
-                          "risk factor",
-                          "affects",
-                          "drug response",
-                          "benign",
-                          "likely benign",
-                          "uncertain significance",
-                          "association",
-                          "conflicting data from submitters",
-                          "other",
-                          "not provided",
-                          "-",
-                          "conflicting interpretation of pathogenicity",
-                          "association not found"
-                        ]
-                      }
+                      "$ref": "#/definitions/clinical_significance"
                     }
                   ]
                 },
@@ -949,27 +929,7 @@
                 },
                 {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "pathogenic",
-                      "likely pathogenic",
-                      "protective",
-                      "risk factor",
-                      "affects",
-                      "drug response",
-                      "benign",
-                      "likely benign",
-                      "uncertain significance",
-                      "association",
-                      "conflicting data from submitters",
-                      "other",
-                      "not provided",
-                      "-",
-                      "conflicting interpretation of pathogenicity",
-                      "association not found"
-                    ]
-                  }
+                  "$ref": "#/definitions/clinical_significance"
                 }
               ]
             },
@@ -1488,6 +1448,29 @@
       "type": "string",
       "description": "Any date provided has to follow the yyyy-mm-dd format",
       "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+    },
+    "clinical_significance": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "affects",
+          "association",
+          "association not found",
+          "benign",
+          "conflicting data from submitters",
+          "conflicting interpretations of pathogenicity",
+          "drug response",
+          "likely benign",
+          "likely pathogenic",
+          "not provided",
+          "other",
+          "pathogenic",
+          "protective",
+          "risk factor",
+          "uncertain significance"
+        ]
+      }
     }
   }
 }

--- a/opentargets.json
+++ b/opentargets.json
@@ -803,8 +803,7 @@
                           "conflicting data from submitters",
                           "other",
                           "not provided",
-                          "-",
-                          "conflicting interpretation of pathogenicity",
+                          "conflicting interpretations of pathogenicity",
                           "association not found"
                         ]
                       }                      
@@ -958,8 +957,7 @@
                       "conflicting data from submitters",
                       "other",
                       "not provided",
-                      "-",
-                      "conflicting interpretation of pathogenicity",
+                      "conflicting interpretations of pathogenicity",
                       "association not found"
                     ]
                   }                      

--- a/opentargets.json
+++ b/opentargets.json
@@ -787,26 +787,7 @@
                     },
                     {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "pathogenic",
-                          "likely pathogenic",
-                          "protective",
-                          "risk factor",
-                          "affects",
-                          "drug response",
-                          "benign",
-                          "likely benign",
-                          "uncertain significance",
-                          "association",
-                          "conflicting data from submitters",
-                          "other",
-                          "not provided",
-                          "conflicting interpretations of pathogenicity",
-                          "association not found"
-                        ]
-                      }                      
+                      "$ref": "#/definitions/clinical_significance"
                     }
                   ]
                 },
@@ -941,26 +922,7 @@
                 },
                 {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "pathogenic",
-                      "likely pathogenic",
-                      "protective",
-                      "risk factor",
-                      "affects",
-                      "drug response",
-                      "benign",
-                      "likely benign",
-                      "uncertain significance",
-                      "association",
-                      "conflicting data from submitters",
-                      "other",
-                      "not provided",
-                      "conflicting interpretations of pathogenicity",
-                      "association not found"
-                    ]
-                  }                      
+                  "$ref": "#/definitions/clinical_significance"
                 }
               ]
             },
@@ -1301,7 +1263,7 @@
       "properties": {
         "id" : {
           "type" : "string",
-          "description" : "Phenotype identifier." 
+          "description" : "Phenotype identifier."
         },
         "term_id": {
           "type": "string",
@@ -1375,7 +1337,7 @@
             },
             {
               "$ref": "#/definitions/score_summed_total"
-            } 
+            }
           ]
         },
         "provenance_type": {
@@ -1475,6 +1437,29 @@
       "type": "string",
       "description": "Any date provided has to follow the yyyy-mm-dd format",
       "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+    },
+    "clinical_significance": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "affects",
+          "association",
+          "association not found",
+          "benign",
+          "conflicting data from submitters",
+          "conflicting interpretations of pathogenicity",
+          "drug response",
+          "likely benign",
+          "likely pathogenic",
+          "not provided",
+          "other",
+          "pathogenic",
+          "protective",
+          "risk factor",
+          "uncertain significance"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
* Adjust enum of clinical significance values
  + Fix typo in one of the levels: “conflicting **interpretations** of pathogenicity” (rather than “interpretation”)
  + Remove “-”, as it does not appear in the list of clinical significance values
  + Sort values alphabetically
  + Verify that the list of values corresponds exactly to the ones which appear in the most recent ClinVar data release (version 2020-08-24)
* Moved enum to the `definitions` section in order to avoid duplication
* Copied the changes to draft-04 schema