### PR TITLE
Get rid of mode_of_inheritance enum and support multiple modes of inheritance

### DIFF
--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -829,11 +829,7 @@
                   "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
-                  "description": "ClinVar mode of inheritance",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "$ref": "#/definitions/mode_of_inheritance"
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",
@@ -903,6 +899,9 @@
             "clinvar_rating": {
               "type": "object",
               "$ref": "#/definitions/clinvar_rating"
+            },
+            "mode_of_inheritance": {
+              "$ref": "#/definitions/mode_of_inheritance"
             },
             "evidence_codes": {
               "description": "An array of evidence codes",
@@ -1469,6 +1468,22 @@
       "required": [
         "star_rating",
         "review_status"
+      ]
+    },
+    "mode_of_inheritance": {
+      "description": "ClinVar mode of inheritance",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
       ]
     }
   }

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -791,27 +791,7 @@
                     },
                     {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "pathogenic",
-                          "likely pathogenic",
-                          "protective",
-                          "risk factor",
-                          "affects",
-                          "drug response",
-                          "benign",
-                          "likely benign",
-                          "uncertain significance",
-                          "association",
-                          "conflicting data from submitters",
-                          "other",
-                          "not provided",
-                          "-",
-                          "conflicting interpretation of pathogenicity",
-                          "association not found"
-                        ]
-                      }
+                      "$ref": "#/definitions/clinical_significance"
                     }
                   ]
                 },
@@ -949,27 +929,7 @@
                 },
                 {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "pathogenic",
-                      "likely pathogenic",
-                      "protective",
-                      "risk factor",
-                      "affects",
-                      "drug response",
-                      "benign",
-                      "likely benign",
-                      "uncertain significance",
-                      "association",
-                      "conflicting data from submitters",
-                      "other",
-                      "not provided",
-                      "-",
-                      "conflicting interpretation of pathogenicity",
-                      "association not found"
-                    ]
-                  }
+                  "$ref": "#/definitions/clinical_significance"
                 }
               ]
             },
@@ -1488,6 +1448,29 @@
       "type": "string",
       "description": "Any date provided has to follow the yyyy-mm-dd format",
       "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+    },
+    "clinical_significance": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "affects",
+          "association",
+          "association not found",
+          "benign",
+          "conflicting data from submitters",
+          "conflicting interpretations of pathogenicity",
+          "drug response",
+          "likely benign",
+          "likely pathogenic",
+          "not provided",
+          "other",
+          "pathogenic",
+          "protective",
+          "risk factor",
+          "uncertain significance"
+        ]
+      }
     }
   }
 }

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -830,28 +830,7 @@
                 },
                 "mode_of_inheritance": {
                   "type": "string",
-                  "description": "ClinVar mode of inheritance",
-                  "enum": [
-                    "autosomal dominant inheritance",
-                    "autosomal recessive inheritance",
-                    "somatic mutation",
-                    "x-linked inheritance",
-                    "autosomal unknown",
-                    "x-linked recessive inheritance",
-                    "sporadic",
-                    "mitochondrial inheritance",
-                    "x-linked dominant inheritance",
-                    "modeofinheritance multiple",
-                    "oligogenic inheritance",
-                    "other",
-                    "y-linked inheritance",
-                    "sex-limited autosomal dominant",
-                    "autosomal dominant inheritance with maternal imprinting",
-                    "genetic anticipation",
-                    "co-dominant",
-                    "autosomal dominant inheritance with paternal imprinting",
-                    "enigma rules, 2015"
-                  ]
+                  "description": "ClinVar mode of inheritance"
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -835,7 +835,16 @@
                     },
                     "review_status": {
                       "type": "string",
-                      "description": "ClinVar review_status of the variant."
+                      "description": "ClinVar review_status of the variant.",
+                      "enum": [
+                        "no assertion provided",
+                        "no assertion criteria provided",
+                        "criteria provided, single submitter",
+                        "criteria provided, conflicting interpretations",
+                        "criteria provided, multiple submitters, no conflicts",
+                        "reviewed by expert panel",
+                        "practice guideline"
+                      ]
                     }
                   },
                   "required": [

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -829,8 +829,11 @@
                   "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
-                  "type": "string",
-                  "description": "ClinVar mode of inheritance"
+                  "description": "ClinVar mode of inheritance",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -826,31 +826,7 @@
                 },
                 "clinvar_rating": {
                   "type": "object",
-                  "properties": {
-                    "star_rating": {
-                      "type": "integer",
-                      "description": "ClinVar star rating of the variant. Int. 0-4",
-                      "maximum": 4,
-                      "minimum": 0
-                    },
-                    "review_status": {
-                      "type": "string",
-                      "description": "ClinVar review_status of the variant.",
-                      "enum": [
-                        "no assertion provided",
-                        "no assertion criteria provided",
-                        "criteria provided, single submitter",
-                        "criteria provided, conflicting interpretations",
-                        "criteria provided, multiple submitters, no conflicts",
-                        "reviewed by expert panel",
-                        "practice guideline"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "star_rating",
-                    "review_status"
-                  ]
+                  "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
                   "type": "string",
@@ -941,6 +917,10 @@
                   "$ref": "#/definitions/clinical_significance"
                 }
               ]
+            },
+            "clinvar_rating": {
+              "type": "object",
+              "$ref": "#/definitions/clinvar_rating"
             },
             "evidence_codes": {
               "description": "An array of evidence codes",
@@ -1480,6 +1460,34 @@
           "uncertain significance"
         ]
       }
+    },
+    "clinvar_rating": {
+      "type": "object",
+      "properties": {
+        "star_rating": {
+          "type": "integer",
+          "description": "ClinVar star rating of the variant. Int. 0-4",
+          "maximum": 4,
+          "minimum": 0
+        },
+        "review_status": {
+          "type": "string",
+          "description": "ClinVar review_status of the variant.",
+          "enum": [
+            "no assertion provided",
+            "no assertion criteria provided",
+            "criteria provided, single submitter",
+            "criteria provided, conflicting interpretations",
+            "criteria provided, multiple submitters, no conflicts",
+            "reviewed by expert panel",
+            "practice guideline"
+          ]
+        }
+      },
+      "required": [
+        "star_rating",
+        "review_status"
+      ]
     }
   }
 }

--- a/opentargets.json
+++ b/opentargets.json
@@ -823,8 +823,11 @@
                   "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
-                  "type": "string",
-                  "description": "ClinVar mode of inheritance"
+                  "description": "ClinVar mode of inheritance",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",

--- a/opentargets.json
+++ b/opentargets.json
@@ -803,8 +803,7 @@
                           "conflicting data from submitters",
                           "other",
                           "not provided",
-                          "-",
-                          "conflicting interpretation of pathogenicity",
+                          "conflicting interpretations of pathogenicity",
                           "association not found"
                         ]
                       }                      
@@ -958,8 +957,7 @@
                       "conflicting data from submitters",
                       "other",
                       "not provided",
-                      "-",
-                      "conflicting interpretation of pathogenicity",
+                      "conflicting interpretations of pathogenicity",
                       "association not found"
                     ]
                   }                      

--- a/opentargets.json
+++ b/opentargets.json
@@ -787,26 +787,7 @@
                     },
                     {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "pathogenic",
-                          "likely pathogenic",
-                          "protective",
-                          "risk factor",
-                          "affects",
-                          "drug response",
-                          "benign",
-                          "likely benign",
-                          "uncertain significance",
-                          "association",
-                          "conflicting data from submitters",
-                          "other",
-                          "not provided",
-                          "conflicting interpretations of pathogenicity",
-                          "association not found"
-                        ]
-                      }                      
+                      "$ref": "#/definitions/clinical_significance"
                     }
                   ]
                 },
@@ -941,26 +922,7 @@
                 },
                 {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "pathogenic",
-                      "likely pathogenic",
-                      "protective",
-                      "risk factor",
-                      "affects",
-                      "drug response",
-                      "benign",
-                      "likely benign",
-                      "uncertain significance",
-                      "association",
-                      "conflicting data from submitters",
-                      "other",
-                      "not provided",
-                      "conflicting interpretations of pathogenicity",
-                      "association not found"
-                    ]
-                  }                      
+                  "$ref": "#/definitions/clinical_significance"
                 }
               ]
             },
@@ -1301,7 +1263,7 @@
       "properties": {
         "id" : {
           "type" : "string",
-          "description" : "Phenotype identifier." 
+          "description" : "Phenotype identifier."
         },
         "term_id": {
           "type": "string",
@@ -1375,7 +1337,7 @@
             },
             {
               "$ref": "#/definitions/score_summed_total"
-            } 
+            }
           ]
         },
         "provenance_type": {
@@ -1475,6 +1437,29 @@
       "type": "string",
       "description": "Any date provided has to follow the yyyy-mm-dd format",
       "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+    },
+    "clinical_significance": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "affects",
+          "association",
+          "association not found",
+          "benign",
+          "conflicting data from submitters",
+          "conflicting interpretations of pathogenicity",
+          "drug response",
+          "likely benign",
+          "likely pathogenic",
+          "not provided",
+          "other",
+          "pathogenic",
+          "protective",
+          "risk factor",
+          "uncertain significance"
+        ]
+      }
     }
   }
 }

--- a/opentargets.json
+++ b/opentargets.json
@@ -823,11 +823,7 @@
                   "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
-                  "description": "ClinVar mode of inheritance",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                  "$ref": "#/definitions/mode_of_inheritance"
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",
@@ -896,6 +892,9 @@
             "clinvar_rating": {
               "type": "object",
               "$ref": "#/definitions/clinvar_rating"
+            },
+            "mode_of_inheritance": {
+              "$ref": "#/definitions/mode_of_inheritance"
             },
             "evidence_codes": {
               "description": "An array of evidence codes",
@@ -1458,6 +1457,22 @@
       "required": [
         "star_rating",
         "review_status"
+      ]
+    },
+    "mode_of_inheritance": {
+      "description": "ClinVar mode of inheritance",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
       ]
     }
   }

--- a/opentargets.json
+++ b/opentargets.json
@@ -829,7 +829,16 @@
                     },
                     "review_status": {
                       "type": "string",
-                      "description": "ClinVar review_status of the variant."
+                      "description": "ClinVar review_status of the variant.",
+                      "enum": [
+                        "no assertion provided",
+                        "no assertion criteria provided",
+                        "criteria provided, single submitter",
+                        "criteria provided, conflicting interpretations",
+                        "criteria provided, multiple submitters, no conflicts",
+                        "reviewed by expert panel",
+                        "practice guideline"
+                      ]
                     }
                   },
                   "required": [

--- a/opentargets.json
+++ b/opentargets.json
@@ -820,31 +820,7 @@
                 },
                 "clinvar_rating": {
                   "type": "object",
-                  "properties": {
-                    "star_rating": {
-                      "type": "integer",
-                      "description": "ClinVar star rating of the variant. Int. 0-4",
-                      "maximum": 4,
-                      "minimum": 0
-                    },
-                    "review_status": {
-                      "type": "string",
-                      "description": "ClinVar review_status of the variant.",
-                      "enum": [
-                        "no assertion provided",
-                        "no assertion criteria provided",
-                        "criteria provided, single submitter",
-                        "criteria provided, conflicting interpretations",
-                        "criteria provided, multiple submitters, no conflicts",
-                        "reviewed by expert panel",
-                        "practice guideline"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "star_rating",
-                    "review_status"
-                  ]
+                  "$ref": "#/definitions/clinvar_rating"
                 },
                 "mode_of_inheritance": {
                   "type": "string",
@@ -934,6 +910,10 @@
                   "$ref": "#/definitions/clinical_significance"
                 }
               ]
+            },
+            "clinvar_rating": {
+              "type": "object",
+              "$ref": "#/definitions/clinvar_rating"
             },
             "evidence_codes": {
               "description": "An array of evidence codes",
@@ -1469,6 +1449,34 @@
           "uncertain significance"
         ]
       }
+    },
+    "clinvar_rating": {
+      "type": "object",
+      "properties": {
+        "star_rating": {
+          "type": "integer",
+          "description": "ClinVar star rating of the variant. Int. 0-4",
+          "maximum": 4,
+          "minimum": 0
+        },
+        "review_status": {
+          "type": "string",
+          "description": "ClinVar review_status of the variant.",
+          "enum": [
+            "no assertion provided",
+            "no assertion criteria provided",
+            "criteria provided, single submitter",
+            "criteria provided, conflicting interpretations",
+            "criteria provided, multiple submitters, no conflicts",
+            "reviewed by expert panel",
+            "practice guideline"
+          ]
+        }
+      },
+      "required": [
+        "star_rating",
+        "review_status"
+      ]
     }
   }
 }

--- a/opentargets.json
+++ b/opentargets.json
@@ -824,28 +824,7 @@
                 },
                 "mode_of_inheritance": {
                   "type": "string",
-                  "description": "ClinVar mode of inheritance",
-                  "enum": [
-                    "autosomal dominant inheritance",
-                    "autosomal recessive inheritance",
-                    "somatic mutation",
-                    "x-linked inheritance",
-                    "autosomal unknown",
-                    "x-linked recessive inheritance",
-                    "sporadic",
-                    "mitochondrial inheritance",
-                    "x-linked dominant inheritance",
-                    "modeofinheritance multiple",
-                    "oligogenic inheritance",
-                    "other",
-                    "y-linked inheritance",
-                    "sex-limited autosomal dominant",
-                    "autosomal dominant inheritance with maternal imprinting",
-                    "genetic anticipation",
-                    "co-dominant",
-                    "autosomal dominant inheritance with paternal imprinting",
-                    "enigma rules, 2015"
-                  ]
+                  "description": "ClinVar mode of inheritance"
                 },
                 "last_evaluated_date": {
                   "$ref": "#/definitions/date",


### PR DESCRIPTION
As discussed in https://github.com/opentargets/platform/issues/1140#issuecomment-668050304, https://github.com/opentargets/platform/issues/1140#issuecomment-683826367. Instead, values from ClinVar will be submitted verbatim.

Also convert string to array of strings, since some ClinVar records contain multiple modes of inheritance.