### PR TITLE
Ag date fix

### DIFF
--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -1486,8 +1486,8 @@
     },
     "date": {
       "type": "string",
-      "description": "Any date provided has to follow the yyyy-mm-dd format or N/A if not available",
-      "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])|N/A"
+      "description": "Any date provided has to follow the yyyy-mm-dd format",
+      "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
     }
   }
 }

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -1481,8 +1481,7 @@
       },
       "required": [
         "provenance_type",
-        "is_associated",
-        "date_asserted"
+        "is_associated"
       ]
     },
     "date": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1470,8 +1470,7 @@
       },
       "required": [
         "provenance_type",
-        "is_associated",
-        "date_asserted"
+        "is_associated"
       ]
     },
     "date": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1475,8 +1475,8 @@
     },
     "date": {
       "type": "string",
-      "description": "Any date provided has to follow the yyyy-mm-dd format or N/A if not available",
-      "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])|N/A"
+      "description": "Any date provided has to follow the yyyy-mm-dd format",
+      "pattern": "[1-2][0-9]{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
     }
   }
 }


### PR DESCRIPTION
date_asserted should not be required for all evidence so it's removed from the `evidence_base` requirements. Note that this only affects those data types that don't specify it as a requirement explicitly.