### PR TITLE
Ag pjo anyof error

### DIFF
--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -727,26 +727,8 @@
               ]
             }
           },
-          "oneOf": [
-            {
-              "required": [
-                "id",
-                "type"
-              ]
-            },
-            {
-              "required": [
-                "rs_id",
-                "type"
-              ]
-            },
-            {
-              "required": [
-                "id",
-                "rs_id",
-                "type"
-              ]
-            }
+          "required": [
+              "type"
           ]
         },
         "evidence": {

--- a/draft4_schemas/opentargets.json
+++ b/draft4_schemas/opentargets.json
@@ -727,7 +727,7 @@
               ]
             }
           },
-          "anyOf": [
+          "oneOf": [
             {
               "required": [
                 "id",
@@ -736,6 +736,13 @@
             },
             {
               "required": [
+                "rs_id",
+                "type"
+              ]
+            },
+            {
+              "required": [
+                "id",
                 "rs_id",
                 "type"
               ]

--- a/opentargets.json
+++ b/opentargets.json
@@ -723,19 +723,8 @@
               ]
             }
           },
-          "anyOf": [
-            {
-              "required": [
-                "id",
-                "type"
-              ]
-            },
-            {
-              "required": [
-                "rs_id",
-                "type"
-              ]
-            }
+          "required": [
+            "type"
           ]
         },
         "evidence": {


### PR DESCRIPTION
The python module we use to generate evidence from a JSON schema (`python_jsonschema_objects`) does not support `anyOf` constructs and `oneOf` is difficult to implement so to avoid issues the `variant` schema will not require any variant ids.