### PR TITLE
Ag url fieldname

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install git+git://github.com/Julian/jsonschema.git@v3.0.0a4#egg=jsonschema
+  - pip install git+git://github.com/Julian/jsonschema.git@v3.0.2#egg=jsonschema
   - wget -O draft7.json http://json-schema.org/draft-07/schema
 script:
   - jsonschema -i opentargets.json draft7.json

--- a/opentargets.json
+++ b/opentargets.json
@@ -51,9 +51,6 @@
         "clinicalStatus": {
           "$ref": "#/definitions/clinicalStatus"
         },
-        "clinicalUrls": {
-          "$ref": "#/definitions/clinicalUrls"
-        },
         "datatypeId": {
           "$ref": "#/definitions/datatypeId"
         },
@@ -68,6 +65,9 @@
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "urls": {
+          "$ref": "#/definitions/urls"
         }
       },
       "required": [
@@ -104,6 +104,9 @@
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "urls": {
+          "$ref": "#/definitions/urls"
         }
       },
       "required": [
@@ -875,32 +878,6 @@
         "Active, not recruiting"
       ]
     },
-    "clinicalUrls": {
-      "type": "array",
-      "description": "Reference to linked clinical information (studies, package inserts, etc.)",
-      "items": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string",
-            "pattern": "https://|http://",
-            "examples": [
-              "https://clinicaltrials.gov/search?id=%22NCT01917656%22"
-            ]
-          },
-          "niceName": {
-            "type": "string",
-            "enum": [
-              "Clinical Trials",
-              "DailyMed",
-              "FDA",
-              "ATC"
-            ]
-          }
-        }
-      },
-      "uniqueItems": true
-    },
     "cohortDescription": {
       "type": "string",
       "description": "Description of the studied cohort",
@@ -1248,6 +1225,34 @@
           "tStart": {
             "type": "integer",
             "description": "Index position where target name starts in sentence"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "urls": {
+      "type": "array",
+      "description": "Reference to linked external resource (e.g. clinical trials, studies, package inserts, reports, etc.)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "pattern": "https://|http://",
+            "examples": [
+              "https://clinicaltrials.gov/search?id=%22NCT01917656%22",
+              "https://search.clinicalgenome.org/kb/gene-validity/d910a9d8-516e-443d-acba-8d61f7574792--2018-06-07T14:23:53"
+
+            ]
+          },
+          "niceName": {
+            "type": "string",
+            "enum": [
+              "Clinical Trials",
+              "DailyMed",
+              "FDA",
+              "ATC"
+            ]
           }
         }
       },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1247,7 +1247,7 @@
           },
           "niceName": {
             "type": "string",
-            "enum": [
+            "examples": [
               "Clinical Trials",
               "DailyMed",
               "FDA",


### PR DESCRIPTION
- `clinicalUrls` has been replaced by `urls` so that it can be used in other datasources like `clingen` - it was originally thought for `ChEMBL`.
- Version of `jsonschema` package upgraded to `3.0.2` which is the same as the minimum version accepted for the validator.