### PR TITLE
Add variantFunctionalConsequenceId to gene2phenotype

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -353,6 +353,9 @@
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "variantFunctionalConsequenceId":  {
+          "$ref": "#/definitions/variantFunctionalConsequenceId"
         }
       },
       "required": [


### PR DESCRIPTION
`variantFunctionalConsequenceId` is needed in gene2phenotype