### PR TITLE
Il 1360 new source and field

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -696,6 +696,9 @@
         "reactionId": {
           "$ref": "#/definitions/reactionId"
         },
+        "reactionName": {
+          "$ref": "#/definitions/reactionName"
+        },
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
         },
@@ -1203,6 +1206,13 @@
       "pattern": "^(R-HSA-)\\d+$",
       "examples": [
         "R-HSA-9660615"
+      ]
+    },
+    "reactionName": {
+      "type": "string",
+      "description": "Name corresponding to the reaction ID",
+      "examples": [
+        "Viral Protein Synthesis"
       ]
     },
     "resourceScore": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -822,6 +822,51 @@
         "targetFromSourceId"
       ],
       "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
+          "const": "uniprot_variants"
+        },
+        "datatypeId": {
+          "$ref": "#/definitions/datatypeId"
+        },
+        "confidence": {
+          "$ref": "#/definitions/confidence"
+        },
+        "diseaseFromSource": {
+          "$ref": "#/definitions/diseaseFromSource"
+        },
+        "diseaseFromSourceId": {
+          "$ref": "#/definitions/diseaseFromSourceId"
+        },
+        "diseaseFromSourceMappedId": {
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "functionalConsequenceId": {
+          "$ref": "#/definitions/functionalConsequenceId"
+        },
+        "literature": {
+          "$ref": "#/definitions/literature"
+        },
+        "targetFromSourceId": {
+          "$ref": "#/definitions/targetFromSourceId"
+        },
+        "targetModulation": {
+          "$ref": "#/definitions/targetModulation"
+        },
+        "variantRsId": {
+          "$ref": "#/definitions/variantRsId"
+        },
+        "variantId": {
+          "$ref": "#/definitions/variantId"
+        }
+      },
+      "required": [
+        "datasourceId",
+        "targetFromSourceId"
+      ],
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -198,6 +198,9 @@
         "datasourceId": {
           "const": "eva"
         },
+        "alleleOrigins": {
+          "$ref": "#/definitions/alleleOrigins"
+        },
         "allelicRequirements": {
           "$ref": "#/definitions/allelicRequirements"
         },
@@ -245,6 +248,9 @@
       "properties": {
         "datasourceId": {
           "const": "eva_somatic"
+        },
+        "alleleOrigins": {
+          "$ref": "#/definitions/alleleOrigins"
         },
         "allelicRequirements": {
           "$ref": "#/definitions/allelicRequirements"
@@ -819,6 +825,18 @@
     }
   ],
   "definitions": {
+    "alleleOrigins" : {
+      "type": "array",
+      "description": "Origin of the variant allele",
+      "items": {
+        "type": "string",
+        "enum": [
+          "somatic",
+          "germline"
+        ]
+      },
+      "uniqueItems": true
+    },
     "allelicRequirements": {
       "type": "array",
       "description": "Inheritance patterns",


### PR DESCRIPTION
This PR covers [#1360](https://github.com/opentargets/platform/issues/1360) with the inclusion of `uniprot_variants` as a data source and a new field called `alleleOrigins`, which is expected to be populated with EVA data.

The [spreadsheet](https://docs.google.com/spreadsheets/d/1vHoyIsQDBNmUfq2IUdZDoz3G457V5cqW/edit#gid=613969206) where we keep track of the different fields has also been updated.