### PR TITLE
Ds schema updates

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -726,8 +726,8 @@
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
-        "functionalConsequenceId": {
-          "$ref": "#/definitions/functionalConsequenceId"
+        "variantFunctionalConsequenceId": {
+          "$ref": "#/definitions/variantFunctionalConsequenceId"
         },
         "literature": {
           "$ref": "#/definitions/literature"
@@ -885,8 +885,8 @@
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
-        "functionalConsequenceId": {
-          "$ref": "#/definitions/functionalConsequenceId"
+        "variantFunctionalConsequenceId": {
+          "$ref": "#/definitions/variantFunctionalConsequenceId"
         },
         "literature": {
           "$ref": "#/definitions/literature"

--- a/opentargets.json
+++ b/opentargets.json
@@ -510,10 +510,10 @@
         "beta": {
           "$ref":  "#/definitions/beta"
         },
-        "oddsRationConfidenceIntervalLower": {
+        "oddsRatioConfidenceIntervalLower": {
           "$ref": "#/definitions/confidenceIntervalLower"
         },
-        "oddsRationConfidenceIntervalUpper": {
+        "oddsRatioConfidenceIntervalUpper": {
           "$ref": "#/definitions/confidenceIntervalUpper"
         },
         "betaConfidenceIntervalLower": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -507,10 +507,19 @@
         "datasourceId": {
           "const": "ot_genetics_portal"
         },
-        "confidenceIntervalLower": {
+        "beta": {
+          "$ref":  "#/definitions/beta"
+        },
+        "oddsRationConfidenceIntervalLower": {
           "$ref": "#/definitions/confidenceIntervalLower"
         },
-        "confidenceIntervalUpper": {
+        "oddsRationConfidenceIntervalUpper": {
+          "$ref": "#/definitions/confidenceIntervalUpper"
+        },
+        "betaConfidenceIntervalLower": {
+          "$ref": "#/definitions/confidenceIntervalLower"
+        },
+        "betaConfidenceIntervalUpper": {
           "$ref": "#/definitions/confidenceIntervalUpper"
         },
         "datatypeId": {
@@ -792,6 +801,9 @@
         "diseaseFromSourceId": {
           "$ref": "#/definitions/diseaseFromSourceId"
         },
+        "diseaseFromSource": {
+          "$ref": "#/definitions/diseaseFromSource"
+        },        
         "literature": {
           "$ref": "#/definitions/literature"
         },
@@ -904,11 +916,7 @@
       "type": "array",
       "description": "Origin of the variant allele",
       "items": {
-        "type": "string",
-        "enum": [
-          "somatic",
-          "germline"
-        ]
+        "type": "string"
       },
       "uniqueItems": true
     },
@@ -919,6 +927,10 @@
         "type": "string"
       },
       "uniqueItems": true
+    },
+    "beta": {
+      "type": "number",
+      "description": "Effect size of numberic traits."
     },
     "biologicalModelAllelicComposition": {
       "type": "string",


### PR DESCRIPTION
**Modifications:**

* `beta` is added to genetics portal.
*  The upper and lower boundaries of the confidence interval is also added.
*  The same definitions are applied for the confidence intervals of beta and odds ratio.
*  Following discussion with Kirill, the enum field is removed from `alleleOrigins` field.
*  `diseaseFromSource` field is added to sysbio
* In reactome and uniprot_variants, `functionalConsequenceId` is removed to `variantFunctionalConsequenceId`