### PR TITLE
Allow MT chromosomes, allow IUPAC ambiguity codes 

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1449,9 +1449,10 @@
     "variantId": {
       "type": "string",
       "description": "Identifier of the variant using CHROM_POS_REF_ALT notation",
-      "pattern": "^[0-9XY]{1,2}_\\d+_[ACTG]+_[ACTG]+$",
+      "pattern": "^[0-9XY]{1,2}|MT_\\d+_[A-Z]+_[A-Z]+$",
       "examples": [
-        "20_41203988_T_C"
+        "20_41203988_T_C",
+        "MT_91234_"
       ]
     },
     "variantRsId": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1449,10 +1449,10 @@
     "variantId": {
       "type": "string",
       "description": "Identifier of the variant using CHROM_POS_REF_ALT notation",
-      "pattern": "^[0-9XY]{1,2}|MT_\\d+_[A-Z]+_[A-Z]+$",
+      "pattern": "^([0-9XY]{1,2}|MT)_\\d+_[A-Z]+_[A-Z]+$",
       "examples": [
         "20_41203988_T_C",
-        "MT_91234_"
+        "MT_91234_C_W"
       ]
     },
     "variantRsId": {


### PR DESCRIPTION
`variantId` field in the json schema needs to be updated to make sure it well accommodates mitochondrial chromosomes and IUPAC [ambiguity codes](https://genome.ucsc.edu/goldenPath/help/iupac.html) for multi-allelic variants. 

The branch validates the following evidence string:

```
{
  "datasourceId": "eva",
  "diseaseFromSourceMappedId": "EFO_1001961",
  "targetFromSourceId": "ENSG00000140505",
  "variantId": "MT_234234_C_W"
}
```

There's a bit of lazy test for the iupac codes as the pattern allows any capital letters, but it would have been excessive to list all possible values.