### PR TITLE
Schema update for EPMC evidence

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -198,8 +198,8 @@
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
-        "pmcid": {
-          "$ref": "#/definitions/pmcid"
+        "pmcIds": {
+          "$ref": "#/definitions/pmcIds"
         }
       },
       "required": [
@@ -1238,10 +1238,15 @@
       },
       "uniqueItems": true
     },
-    "pmcId": {
-      "type": "string",
-      "description": "PubMed Central identifier of full text publication.",
-      "pattern": "PMC\\d+"
+    "pmcIds": {
+      "type": "array",
+      "description": "List of PubMed Central identifiers of full text publication.",
+      "items": {
+        "type": "string",
+        "pattern": "PMC\\d+",
+        "description": "Literature identifer in PubMed Central"
+      },
+      "uniqueItems": true
     },
     "pValueExponent": {
       "type": "integer",

--- a/opentargets.json
+++ b/opentargets.json
@@ -180,9 +180,6 @@
         "datatypeId": {
           "$ref": "#/definitions/datatypeId"
         },
-        "diseaseFromSource": {
-          "$ref": "#/definitions/diseaseFromSource"
-        },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceId"
         },
@@ -192,9 +189,6 @@
         "resourceScore": {
           "$ref": "#/definitions/resourceScore"
         },
-        "targetFromSource": {
-          "$ref": "#/definitions/targetFromSource"
-        },
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
         },
@@ -203,6 +197,9 @@
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "pmcid": {
+          "$ref": "#/definitions/pmcid"
         }
       },
       "required": [
@@ -1240,6 +1237,11 @@
         "additionalProperties": false
       },
       "uniqueItems": true
+    },
+    "pmcId": {
+      "type": "string",
+      "description": "PubMed Central identifier of full text publication.",
+      "pattern": "PMC\\d+"
     },
     "pValueExponent": {
       "type": "integer",

--- a/opentargets.json
+++ b/opentargets.json
@@ -204,7 +204,7 @@
       },
       "required": [
         "datasourceId",
-        "targetFromSource"
+        "targetFromSourceId"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1243,7 +1243,7 @@
       "description": "List of PubMed Central identifiers of full text publication.",
       "items": {
         "type": "string",
-        "pattern": "PMC\\d+",
+        "pattern": "^PMC\\d+$",
         "description": "Literature identifer in PubMed Central"
       },
       "uniqueItems": true


### PR DESCRIPTION
Small updates on the schema reflecting the specification under #1462 and #1501

* Adding new field `pmcIds` to the schema
* Removing `diseaseFromSource` and `targetFromSource` from epmc evidence
* Allowing a list of PubmedCentral identifiers (under `pmcIds`) for epmc evidence
