### PR TITLE
Remove duplicated diseaseFromSourceMappedId

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -195,9 +195,6 @@
         "textMiningSentences": {
           "$ref": "#/definitions/textMiningSentences"
         },
-        "diseaseFromSourceMappedId": {
-          "$ref": "#/definitions/diseaseFromSourceMappedId"
-        },
         "pmcIds": {
           "$ref": "#/definitions/pmcIds"
         }


### PR DESCRIPTION
The diseaseFromSourceMappedId field was duplicated in the europepmc evidence object, as reported by Alok from Uniprot.