### PR TITLE
Update and sort the list of clinical significance values

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -987,7 +987,7 @@
           "pathogenic",
           "protective",
           "risk factor",
-          "uncertain significance",
+          "uncertain significance"
         ]
       },
       "uniqueItems": true

--- a/opentargets.json
+++ b/opentargets.json
@@ -972,20 +972,22 @@
           "pathogenic"
         ],
         "enum": [
-          "uncertain significance",
-          "pathogenic",
-          "likely benign",
-          "association not found",
-          "other",
-          "benign",
+          "affects",
           "association",
-          "risk factor",
+          "association not found",
+          "benign",
+          "confers sensitivity",
+          "conflicting data from submitters",
+          "conflicting interpretations of pathogenicity",
+          "drug response",
+          "likely benign",
           "likely pathogenic",
           "not provided",
-          "affects",
+          "other",
+          "pathogenic",
           "protective",
-          "drug response",
-          "conflicting interpretations of pathogenicity"
+          "risk factor",
+          "uncertain significance",
         ]
       },
       "uniqueItems": true


### PR DESCRIPTION
Related to https://github.com/EBIvariation/eva-opentargets/issues/243.

When running the ClinVar pipeline, it was discovered that two levels of clinical significance values are present in ClinVar, but not in our schema. This discrepancy has been present for a while, it just didn't trigger before because less evidence strings were generated (only the EFO mapped ones).

I've added the two missing levels (“confers sensitivity” and “conflicting data from submitters”) and also sorted the list lexicographically for readability.