### PR TITLE
Adding Orphanet as new data source.

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -505,6 +505,45 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "orphanet"
+        },
+        "alleleOrigins": {
+          "$ref": "#/definitions/alleleOrigins"
+        },
+        "confidence": {
+          "$ref": "#/definitions/confidence"
+        },
+        "datatypeId": {
+          "ref": "#/definitions/datatypeId"
+        },        
+        "diseaseFromSource": {
+          "$ref": "#/definitions/diseaseFromSource"
+        },
+        "diseaseFromSourceId": {
+          "$ref": "#/definitions/diseaseFromSourceId"
+        },
+        "diseaseFromSourceMappedId": {
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "literature": {
+          "$ref": "#/definitions/literature"
+        },
+        "targetFromSource": {
+          "$ref": "#/definitions/targetFromSource"
+        },
+        "targetFromSourceId": {
+          "$ref": "#/definitions/targetFromSourceId"
+        }
+      },
+      "required": [
+        "datasourceId",
+        "targetFromSourceId"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "ot_genetics_portal"
         },
         "beta": {


### PR DESCRIPTION
The new schema describes the following example:

```json
{
  "diseaseFromSourceId": "Orphanet_157716",
  "diseaseFromSource": "Late infantile CACH syndrome",
  "literature": [
    "20301435"
  ],
  "confidence": "Assessed",
  "targetFromSource": "eukaryotic translation initiation factor 2B subunit alpha",
  "targetFromSourceId": "ENSG00000111361",
  "dataSourceId": "orphanet",
  "datatypeId": "genetic_association",
  "alleleOrigins": [
    "germline"
  ],
  "diseaseFromSourceMappedId": "Orphanet_157716"
}
```