### PR TITLE
Adding projectId to ot_genetics evidence.

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -576,6 +576,9 @@
         "oddsRatio": {
           "$ref": "#/definitions/oddsRatio"
         },
+        "projectId": {
+          "$ref": "#/definitions/projectId"
+        },
         "pValueExponent": {
           "$ref": "#/definitions/pValueExponent"
         },
@@ -1285,6 +1288,14 @@
         "description": "Literature identifer in PubMed Central"
       },
       "uniqueItems": true
+    },
+    "projectId":{
+      "type": "string",
+      "description": "Broader category of the actual study. The identifer of the project that generated the data.",
+      "examples": [
+        "FINNGEN",
+        "UKBB"
+      ]
     },
     "pValueExponent": {
       "type": "integer",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1291,7 +1291,7 @@
     },
     "projectId":{
       "type": "string",
-      "description": "Broader category of the actual study. The identifer of the project that generated the data.",
+      "description": "The identifer of the project that generated the data.",
       "examples": [
         "FINNGEN",
         "UKBB"


### PR DESCRIPTION
* New field is added to the schema: `projectId`
* Captures identifier of the project, under which the data was generated.
* Currently Genetics Portal sourced data has this field allowed. 