### PR TITLE
Update PhenoDigm schema to align with the mouse phenotypes object

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -515,7 +515,7 @@
         },
         "datatypeId": {
           "ref": "#/definitions/datatypeId"
-        },        
+        },
         "diseaseFromSource": {
           "$ref": "#/definitions/diseaseFromSource"
         },
@@ -660,8 +660,11 @@
         "targetInModel": {
           "$ref": "#/definitions/targetInModel"
         },
-        "targetInModelId": {
-          "$ref": "#/definitions/targetInModelId"
+        "targetInModelEnsemblId": {
+          "$ref": "#/definitions/targetInModelEnsemblId"
+        },
+        "targetInModelMgiId": {
+          "$ref": "#/definitions/targetInModelMgiId"
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
@@ -1409,12 +1412,20 @@
         "3-mercaptopyruvate sulfurtransferase"
       ]
     },
-    "targetInModelId": {
+    "targetInModelEnsemblId": {
       "type": "string",
-      "description": "Target ID in animal model",
+      "description": "Target Ensembl ID in animal model",
       "pattern": "^(ENSMUSG)\\d+$",
       "examples": [
         "ENSMUSG00000014773"
+      ]
+    },
+    "targetInModelMgiId": {
+      "type": "string",
+      "description": "Target MGI ID in animal model",
+      "pattern": "^(MGI:)\\d+$",
+      "examples": [
+        "MGI:104659"
       ]
     },
     "targetInModel": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -651,6 +651,9 @@
         "diseaseModelAssociatedModelPhenotypes": {
           "$ref": "#/definitions/diseaseModelAssociatedModelPhenotypes"
         },
+        "literature": {
+          "$ref": "#/definitions/literature"
+        },
         "resourceScore": {
           "$ref": "#/definitions/resourceScore"
         },


### PR DESCRIPTION
Changes from https://github.com/opentargets/platform/issues/1471:
* Separate Ensembl and MGI identifiers for animal models
* Add literature field for PhenoDigm evidence