### PR TITLE
Adding new fields to json schema for ot_crispr datasets.

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1260,7 +1260,7 @@
     },
     "direction": {
       "type": "string",
-      "description": "Which end of the distribution the target was picked.",
+      "description": "Which end of the distribution the target was picked from.",
       "examples": [
         "upper tail",
         "lower tail"

--- a/opentargets.json
+++ b/opentargets.json
@@ -1236,7 +1236,7 @@
     },
     "crisprScreenLibrary": {
       "type": "string",
-      "description": "The applied screening library in the CRISPR/CAS9 prject.",
+      "description": "The applied screening library in the CRISPR/CAS9 project.",
       "examples": [
         "Kosuke v1.1 (Behan et al., 2018)"
       ]

--- a/opentargets.json
+++ b/opentargets.json
@@ -542,6 +542,57 @@
       "additionalProperties": false
     },
     {
+      "properties":{
+        "datasourceId": {
+          "const": "ot_crispr"
+        },
+        "cellLineBackground": {
+          "$ref": "#/definitions/cellLineBackground"
+        },
+        "cellType": {
+          "$ref": "#/definitions/cellType"
+        },
+        "contrast": {
+          "$ref": "#/definitions/contrast"
+        },
+        "crisprScreenLibrary": {
+          "$ref": "#/definitions/crisprScreenLibrary"
+        },
+        "datatypeId": {
+          "$ref": "#/definitions/datatypeId"
+        },
+        "direction": {
+          "$ref": "#/definitions/direction"
+        },
+        "diseaseFromSourceMappedId": {
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "geneticBackground": {
+          "$ref": "#/definitions/geneticBackground"
+        },
+        "projectId": {
+          "$ref": "#/definitions/projectId"
+        },
+        "resourceScore": {
+          "$ref": "#/definitions/resourceScore"
+        },
+        "studyOverview": {
+          "$ref": "#/definitions/studyOverview"
+        },
+        "studyId": {
+          "$ref": "#/definitions/studyId"
+        },
+        "targetFromSourceId": {
+          "$ref": "#/definitions/targetFromSourceId"
+        }
+      },
+      "required": [
+        "datasourceId",
+        "targetFromSourceId"
+      ],
+      "additionalProperties": false
+    },
+    {
       "properties": {
         "datasourceId": {
           "const": "ot_genetics_portal"
@@ -1005,6 +1056,23 @@
       ],
       "pattern": "^(MGI:)\\d+$"
     },
+    "cellLineBackground": {
+      "type": "string",
+      "description": "Background of the derived cell lines.",
+      "examples": [
+        "KOLF2-C1"
+      ]
+
+    },
+    "cellType": {
+      "type": "string",
+      "description": "The studied cell type. Preferably the cell line ontology label.",
+      "examples": [
+        "HaCaT keratinocytes",
+        "iPSC derived cortical neurons"
+      ]
+
+    },
     "clinicalPhase": {
       "type": "integer",
       "description": "Phase of the clinical trial",
@@ -1110,6 +1178,13 @@
         "glioblastoma vs normal"
       ]
     },
+    "crisprScreenLibrary": {
+      "type": "string",
+      "description": "The applied screening library in the CRISPR/CAS9 prject.",
+      "examples": [
+        "Kosuke v1.1 (Behan et al., 2018)"
+      ]
+    },
     "datasourceId": {
       "type": "string"
     },
@@ -1123,8 +1198,18 @@
         "animal_model",
         "somatic_mutation",
         "known_drug",
-        "genetic_association"
+        "genetic_association",
+        "ot_partner"
       ]
+    },
+    "direction": {
+      "type": "string",
+      "description": "Which end of the distribution the target was picked.",
+      "examples": [
+        "upper tail",
+        "lower tail"
+      ]
+
     },
     "diseaseCellLines": {
       "type": "array",
@@ -1204,6 +1289,10 @@
         "CHEMBL1431",
         "CHEMBL803"
       ]
+    },
+    "geneticBackground": {
+      "type": "string",
+      "description": "Additional genetic background of the applied cell line in the CRISPR screen."
     },
     "literature": {
       "type": "array",
@@ -1300,7 +1389,8 @@
       "description": "The identifer of the project that generated the data.",
       "examples": [
         "FINNGEN",
-        "UKBB"
+        "UKBB",
+        "OTAR033"
       ]
     },
     "pValueExponent": {


### PR DESCRIPTION
The schema validates the following crispr d/t evidence strings:

```json
{"targetFromSourceId": "YIF1B", "diseaseFromSourceMappedId": "EFO_0000249", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0063227, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "YIF1B", "diseaseFromSourceMappedId": "EFO_0003096", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0063227, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "TCP10L2", "diseaseFromSourceMappedId": "EFO_0000249", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0063799, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "TCP10L2", "diseaseFromSourceMappedId": "EFO_0003096", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0063799, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "ABCC9", "diseaseFromSourceMappedId": "EFO_0000249", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0082308, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "ABCC9", "diseaseFromSourceMappedId": "EFO_0003096", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0082308, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "ART3", "diseaseFromSourceMappedId": "EFO_0000249", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0027475, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "ART3", "diseaseFromSourceMappedId": "EFO_0003096", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0027475, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "IL15", "diseaseFromSourceMappedId": "EFO_0000249", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0022693, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
{"targetFromSourceId": "IL15", "diseaseFromSourceMappedId": "EFO_0003096", "projectId": "OTAR036", "studyId": "OTAR036_TAU_uptake_1", "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein", "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)", "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)", "cellType": "iPSC derived cortical neurons", "cellLineBackground": "KOLF2-C1", "direction": "upper tail", "resourceScore": 0.0022693, "datasourceId": "ot_crispr", "datatypeId": "ot_partner"}
```