### PR TITLE
Added cancer_genome_interpreter as a source

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -55,6 +55,57 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "cancer_genome_interpreter"
+        }
+      },
+      "biomarker": {
+        "$ref": "#/definitions/biomarker"
+      },
+      "datatypeId": {
+        "$ref": "#/definitions/datatypeId"
+      },
+      "diseaseFromSource": {
+        "$ref": "#/definitions/diseaseFromSource"
+      },
+      "diseaseFromSourceMappedId": {
+        "$ref": "#/definitions/diseaseFromSourceMappedId"
+      },
+      "drugFromSource": {
+        "$ref": "#/definitions/drugFromSource"
+      },
+      "drugId": {
+        "$ref": "#/definitions/drugId"
+      },
+      "drugResponse": {
+        "$ref": "#/definitions/drugResponse"
+      },
+      "confidence": {
+        "$ref": "#/definitions/confidence"
+      },
+      "literature": {
+        "$ref": "#/definitions/literature"
+      },
+      "urls": {
+        "$ref": "#/definitions/urls"
+      },
+      "targetFromSourceId": {
+        "$ref": "#/definitions/targetFromSourceId"
+      },
+      "variantFunctionalConsequenceId": {
+        "$ref": "#/definitions/variantFunctionalConsequenceId"
+      },
+      "variantAminoacidDescriptions": {
+        "$ref": "#/definitions/variantAminoacidDescriptions"
+      },
+      "required": [
+        "datasourceId",
+        "targetFromSourceId"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "chembl"
         },
         "clinicalPhase": {
@@ -1005,6 +1056,13 @@
       ],
       "pattern": "^(MGI:)\\d+$"
     },
+    "biomarker": {
+      "type": "string",
+      "description": "Altered characteristic that influences the disease process.",
+      "examples": [
+        "ABL1:E275K"
+      ]
+    },
     "clinicalPhase": {
       "type": "integer",
       "description": "Phase of the clinical trial",
@@ -1196,6 +1254,13 @@
       },
       "uniqueItems": true
     },
+    "drugFromSource": {
+      "type": "string",
+      "description": "Drug name/family in resource of origin.",
+      "examples": [
+        "Imatinib"
+      ]
+    },
     "drugId": {
       "type": "string",
       "description": "Drug molecule ID",
@@ -1203,6 +1268,13 @@
       "examples": [
         "CHEMBL1431",
         "CHEMBL803"
+      ]
+    },
+    "drugResponse": {
+      "type": "string",
+      "description": "Patterns of drug response in the EFO ontology.",
+      "examples": [
+        "GO_0042493"
       ]
     },
     "literature": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -56,8 +56,7 @@
       "properties": {
         "datasourceId": {
           "const": "cancer_genome_interpreter"
-        }
-      },
+        },
       "biomarker": {
         "$ref": "#/definitions/biomarker"
       },
@@ -96,7 +95,8 @@
       },
       "variantAminoacidDescriptions": {
         "$ref": "#/definitions/variantAminoacidDescriptions"
-      },
+      }
+    },
       "required": [
         "datasourceId",
         "targetFromSourceId"


### PR DESCRIPTION
This version of the schema validates cancer biomarkers strings such as:

```
{"datasourceId":"cancer_genome_interpreter","datatypeId":"affected_pathway","biomarker":"AKT2 amplification","drugFromSource":"MK2206","drugResponse":"GO_0042493","targetFromSourceId":"AKT2","diseaseFromSource":"Any cancer type","diseaseFromSourceMappedId":"EFO_0000311","confidence":"Pre-clinical","variantFunctionalConsequenceId":"SO_0001563","urls":[{"niceName":"EORTC-NCI-AACR Symposium on Molecular Targets and Cancer Therapeutics 2014","url":"https://www.ecco-org.eu/Events/Past-conferences/EORTC_NCI_AACR_2014"}]}
{"datasourceId":"cancer_genome_interpreter","datatypeId":"affected_pathway","biomarker":"ERBB2 overexpression","drugFromSource":"MK2206","drugResponse":"GO_0042493","targetFromSourceId":"ERBB2","diseaseFromSource":"Solid tumors","diseaseFromSourceMappedId":"NCIT_C9292","confidence":"Early trials","variantFunctionalConsequenceId":"SO_0001540","literature":["26104654"],"urls":[{"niceName":"American Society of Clinical Oncology Annual Meeting 2013","url":"https://meetinglibrary.asco.org/browse-meetings/2013%20ASCO%20Annual%20Meeting"}]}
```