### PR TITLE
Cancer Biomarkers schema v2

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -57,8 +57,8 @@
         "datasourceId": {
           "const": "cancer_genome_interpreter"
         },
-      "biomarker": {
-        "$ref": "#/definitions/biomarker"
+      "biomarkers": {
+        "$ref": "#/definitions/biomarkers"
       },
       "datatypeId": {
         "$ref": "#/definitions/datatypeId"
@@ -89,14 +89,8 @@
       },
       "targetFromSourceId": {
         "$ref": "#/definitions/targetFromSourceId"
-      },
-      "variantFunctionalConsequenceId": {
-        "$ref": "#/definitions/variantFunctionalConsequenceId"
-      },
-      "variantAminoacidDescriptions": {
-        "$ref": "#/definitions/variantAminoacidDescriptions"
       }
-    },
+      },
       "required": [
         "datasourceId",
         "targetFromSourceId"
@@ -1122,12 +1116,42 @@
         "iPSC derived cortical neurons"
       ]
     },
-    "biomarker": {
-      "type": "string",
-      "description": "Altered characteristic that influences the disease process.",
-      "examples": [
-        "ABL1:E275K"
-      ]
+    "biomarkers": {
+      "type": "array",
+      "description": "List of biomarkers.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Altered characteristics that influences the disease process.",
+            "examples": [
+              "BRAF (V600E,V600D,V600K,V600M,V600G,V600R)"
+            ]
+          },
+          "individualMutation": {
+            "type": "string",
+            "examples": [
+              "BRAF:V600M"
+            ]
+          },
+          "variantFunctionalConsequenceIds": {
+            "type": "array",
+            "description": "Sequence ontology (SO) identifiers of the functional consequence of the variants",
+            "items": {
+              "$ref": "#/definitions/variantFunctionalConsequenceId"
+            }
+          },
+          "variantId": {
+            "type": "string",
+            "description": "Identifier in CHROM_POS_REF_ALT notation of the disease-causing variant when a biomarker is present.",
+            "examples": [
+              "7_140453137_C_T"
+            ]
+          }
+        }
+      },
+      "uniqueItems": true
     },
     "clinicalPhase": {
       "type": "integer",
@@ -1696,7 +1720,7 @@
     },
     "variantId": {
       "type": "string",
-      "description": "Identifier of the variant using CHROM_POS_REF_ALT notation",
+      "description": "Identifier in CHROM_POS_REF_ALT notation of the disease-causing variant.",
       "pattern": "^([0-9XY]{1,2}|MT)_\\d+_[A-Z]+_[A-Z]+$",
       "examples": [
         "20_41203988_T_C",

--- a/opentargets.json
+++ b/opentargets.json
@@ -57,11 +57,14 @@
         "datasourceId": {
           "const": "cancer_genome_interpreter"
         },
+      "datatypeId": {
+        "$ref": "#/definitions/datatypeId"
+      },
       "biomarkers": {
         "$ref": "#/definitions/biomarkers"
       },
-      "datatypeId": {
-        "$ref": "#/definitions/datatypeId"
+      "confidence": {
+        "$ref": "#/definitions/confidence"
       },
       "diseaseFromSource": {
         "$ref": "#/definitions/diseaseFromSource"
@@ -78,17 +81,14 @@
       "drugResponse": {
         "$ref": "#/definitions/drugResponse"
       },
-      "confidence": {
-        "$ref": "#/definitions/confidence"
-      },
       "literature": {
         "$ref": "#/definitions/literature"
       },
-      "urls": {
-        "$ref": "#/definitions/urls"
-      },
       "targetFromSourceId": {
         "$ref": "#/definitions/targetFromSourceId"
+      },
+      "urls": {
+        "$ref": "#/definitions/urls"
       }
       },
       "required": [

--- a/opentargets.json
+++ b/opentargets.json
@@ -1163,10 +1163,6 @@
                 "examples": [
                   "GO_0010467"
                 ]
-              },
-              "label": {
-                "type": "string",
-                "description": "Regulation or background expression processes. Preferably the Gene Ontology label."
               }
             }
           },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1116,42 +1116,60 @@
         "iPSC derived cortical neurons"
       ]
     },
+    "biomarkerName": {
+      "type": "string",
+      "description": "Altered characteristics that influences the disease process.",
+      "examples": [
+        "BRAF (V600E,V600D,V600K,V600M,V600G,V600R)"
+      ]
+    },
     "biomarkers": {
-      "type": "array",
+      "type": "object",
       "description": "List of biomarkers.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Altered characteristics that influences the disease process.",
-            "examples": [
-              "BRAF (V600E,V600D,V600K,V600M,V600G,V600R)"
-            ]
-          },
-          "individualMutation": {
-            "type": "string",
-            "examples": [
-              "BRAF:V600M"
-            ]
-          },
-          "variantFunctionalConsequenceIds": {
-            "type": "array",
-            "description": "Sequence ontology (SO) identifiers of the functional consequence of the variants",
-            "items": {
-              "$ref": "#/definitions/variantFunctionalConsequenceId"
+      "properties": {
+        "variant": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "examples": [
+                  "BRAF:V600M"
+                ]
+              },
+              "id": {
+                "$ref": "#/definitions/variantId"
+              },
+              "variantFunctionalConsequenceId": {
+                "$ref": "#/definitions/variantFunctionalConsequenceId"
+              }
             }
           },
-          "variantId": {
-            "type": "string",
-            "description": "Identifier in CHROM_POS_REF_ALT notation of the disease-causing variant when a biomarker is present.",
-            "examples": [
-              "7_140453137_C_T"
-            ]
-          }
+          "uniqueItems": true
+        },
+        "geneExpression": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Gene Ontology (GO) identifiers of regulation or background expression processes.",
+                "pattern": "^GO_\\d+",
+                "examples": [
+                  "GO_0010467"
+                ]
+              },
+              "label": {
+                "type": "string",
+                "description": "Regulation or background expression processes. Preferably the Gene Ontology label."
+              }
+            }
+          },
+          "uniqueItems": true
         }
-      },
-      "uniqueItems": true
+      }
     },
     "clinicalPhase": {
       "type": "integer",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1156,6 +1156,12 @@
           "items": {
             "type": "object",
             "properties": {
+              "name": {
+                "type": "string",
+                "examples": [
+                  "ANXA1:over"
+                ]
+              },
               "id": {
                 "type": "string",
                 "description": "Gene Ontology (GO) identifiers of regulation or background expression processes.",

--- a/opentargets.json
+++ b/opentargets.json
@@ -60,6 +60,9 @@
       "datatypeId": {
         "$ref": "#/definitions/datatypeId"
       },
+      "biomarkerName": {
+        "$ref": "#/definitions/biomarkerName"
+      },
       "biomarkers": {
         "$ref": "#/definitions/biomarkers"
       },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1158,6 +1158,7 @@
             "properties": {
               "name": {
                 "type": "string",
+                "description": "Raw gene expression annotation from the source",
                 "examples": [
                   "ANXA1:over"
                 ]


### PR DESCRIPTION
### Updates
- [X] `variantAminoacidDescriptions`, `variantFunctionalConsequenceId` have been removed from root.
- [X] `biomarker` is no longer a string at the root level. It has been renamed to `biomarkers` to be an array of structs that collects all the variant information
- [X] `biomarkers.name`: the name of the biomarker as shown in the data source. This field contains all the variants if multiple are reported. This field is common for all objects in the array.
- [X] `biomarkers.individualMutation`: when available, the precise mutation the other fields refer to is described in this field.
- [X] `biomarkers.variantId`: the genomic coordinates of the individual mutation in the CHROM_POS_REF_ALT notation
- [X] `variantFunctionalConsequenceIds`: Array with the possible functional consequences of the biomarker. As the biomarker can report multiple variants, this field can also contain multiple SO codes.
- [X] `variantId` description has been updated to establish the difference with `biomarkers.variantId`.

### Concerns
I'd like to raise the question of whether the name for the biomarker should be at the `biomarkers` root level and not be exploded for all individual mutations.
```
# I mean this:
'biomarkers' : {
    'name': str,
    'variantFunctionalConsequenceIds' arr
    'variant' : [
        'individualMutation': str,
        'variantId': str,
    ]
}
# As opposed to the current version:
'biomarkers': [{
    'name': str,
    'individualMutation': str,
    'variantId': str,
    'variantFunctionalConsequenceIds': arr
}]
```
The rationale is to have the name of the biomarker easily accessible without needing to explode the `biomarkers` array.
The only con I can think of is that a more complex structure makes a more complex parsing of the data.