### PR TITLE
Making the json schema more strict

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1147,7 +1147,8 @@
               "variantFunctionalConsequenceId": {
                 "$ref": "#/definitions/variantFunctionalConsequenceId"
               }
-            }
+            },
+            "additionalProperties": false
           },
           "uniqueItems": true
         },
@@ -1171,7 +1172,8 @@
                   "GO_0010467"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           },
           "uniqueItems": true
         }

--- a/opentargets.json
+++ b/opentargets.json
@@ -1175,7 +1175,8 @@
           },
           "uniqueItems": true
         }
-      }
+      },
+      "additionalProperties": false
     },
     "clinicalPhase": {
       "type": "integer",
@@ -1358,7 +1359,8 @@
           "label": {
             "type": "string"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "uniqueItems": true
     },
@@ -1381,7 +1383,8 @@
               "abnormal skin morphology"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "uniqueItems": true
     },
@@ -1457,7 +1460,8 @@
             "description": "Number of cohort samples in which target is mutated with a specific mutation type",
             "exclusiveMinimum": 0
           }
-        }
+        },
+        "additionalProperties": false
       },
       "uniqueItems": true
     },
@@ -1687,7 +1691,8 @@
             "type": "integer",
             "description": "Index position where target name starts in sentence"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "uniqueItems": true
     },
@@ -1730,7 +1735,8 @@
               "ATC"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "uniqueItems": true
     },


### PR DESCRIPTION
Although the json schema is quite flat, we still have some nesting where required. We have some objects and some arrays, which can contain objects. These objects were leniently defined by allowing other properties than the defined ones. This is now ended by the addition of `"additionalProperties": false` for every object definition. 

This changes should not have any effect on existing evidence.