### PR TITLE
Adding schema describing TEP dataset.

### DIFF
--- a/opentargets_tep.json
+++ b/opentargets_tep.json
@@ -20,7 +20,7 @@
       ],
       "pattern": "^https://|http://"
     },
-    "threapeuticArea": {
+    "therapeuticArea": {
       "type": ["string", "null"],
       "description": "Broad description of the therapeutic area relevant to the target. Might be more terms separated by comma.",
       "examples": [

--- a/opentargets_tep.json
+++ b/opentargets_tep.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenTargets-tep",
+  "description": "OpenTargets TEP (Target Enabling Package) objects",
+  "type": "object",
+  "properties": {
+    "targetFromSource" : {
+      "type": "string",
+      "description": "Target symbol/name as downloaded from the source",
+      "examples": [
+        "DHTKD1",
+        "Moesin"
+      ]
+    },
+    "tepUrl": {
+      "type": ["string", "null"],
+      "description": "Link pointing to the TEP page.",
+      "examples": [
+        "https://www.thesgc.org/tep/moesin"
+      ],
+      "pattern": "^https://|http://"
+    },
+    "threapeuticArea": {
+      "type": ["string", "null"],
+      "description": "Broad description of the therapeutic area relevant to the target. Might be more terms separated by comma.",
+      "examples": [
+        "Metabolic diseases",
+        "Sickle cell disease (SCD), Neurological"
+      ]
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Description of the target.",
+      "examples": [
+        "Fibrinogen-like globe domain of human Tenascin-C (hFBG-C)"
+      ]
+    }
+  },
+  "required": [
+    "targetFromSource",
+    "tepUrl",
+    "threapeuticArea",
+    "description"
+  ],
+  "additionalProperties": false
+}

--- a/opentargets_tep.json
+++ b/opentargets_tep.json
@@ -4,7 +4,7 @@
   "description": "OpenTargets TEP (Target Enabling Package) objects",
   "type": "object",
   "properties": {
-    "targetFromSource" : {
+    "targetFromSourceId" : {
       "type": "string",
       "description": "Target symbol/name as downloaded from the source",
       "examples": [

--- a/opentargets_tep.json
+++ b/opentargets_tep.json
@@ -12,7 +12,7 @@
         "Moesin"
       ]
     },
-    "tepUrl": {
+    "url": {
       "type": ["string", "null"],
       "description": "Link pointing to the TEP page.",
       "examples": [

--- a/opentargets_tep.json
+++ b/opentargets_tep.json
@@ -6,7 +6,7 @@
   "properties": {
     "targetFromSourceId" : {
       "type": "string",
-      "description": "Target symbol/name as downloaded from the source",
+      "description": "Target ID in resource of origin (accepted sources include Ensembl gene ID, Uniprot ID, gene symbol)",
       "examples": [
         "DHTKD1",
         "Moesin"


### PR DESCRIPTION
Quite simple case. This is the document:

```json
{
  "targetFromSource": "SLC12A4",
  "tepUrl": "https://www.thesgc.org/tep/slc12a4slc12a6",
  "threapeuticArea": "Sickle cell disease (SCD), Neurological",
  "description": "Potassium/Chloride Co-transporter 1 and 3 (KCC1/KCC3; SLC12A4/SLC12A6)"
}
```