### PR TITLE
Make JSON more strict with required fields checks

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1889,7 +1889,7 @@
           "section": {
             "type": "string",
             "description": "Section in which sentence occurs",
-            "enum": [
+            "examples": [
               "title",
               "table",
               "other",

--- a/opentargets.json
+++ b/opentargets.json
@@ -445,8 +445,16 @@
         }
       },
       "required": [
+        "alleleOrigins",
+        "clinicalSignificances",
+        "cohortPhenotypes",
+        "confidence",
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "studyId",
+        "targetFromSourceId",
+        "variantFunctionalConsequenceId",
+        "variantId"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -897,7 +897,6 @@
         "biologicalModelGeneticBackground",
         "datasourceId",
         "diseaseFromSource",
-        "diseaseModelAssociatedModelPhenotypes",
         "resourceScore",
         "targetFromSourceId",
         "targetInModel",

--- a/opentargets.json
+++ b/opentargets.json
@@ -664,7 +664,10 @@
         }
       },
       "required": [
+        "alleleOrigins",
+        "confidence",
         "datasourceId",
+        "diseaseFromSource",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -946,6 +946,9 @@
       },
       "required": [
         "datasourceId",
+        "diseaseFromSource",
+        "pathways",
+        "resourceScore",
         "targetFromSourceId"
       ],
       "additionalProperties": false
@@ -1633,6 +1636,7 @@
             ]
           }
         },
+        "required": ["id"],
         "additionalProperties": false
       },
       "uniqueItems": true

--- a/opentargets.json
+++ b/opentargets.json
@@ -1188,8 +1188,12 @@
         }
       },
       "required": [
+        "confidence",
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "literature",
+        "targetFromSourceId",
+        "targetModulation"
       ],
       "additionalProperties": false
     }

--- a/opentargets.json
+++ b/opentargets.json
@@ -492,7 +492,14 @@
         }
       },
       "required": [
+        "confidence",
+        "contrast",
         "datasourceId",
+        "log2FoldChangePercentileRank",
+        "log2FoldChangeValue",
+        "resourceScore",
+        "studyId",
+        "studyOverview",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -578,7 +578,11 @@
         }
       },
       "required": [
+        "cohortPhenotypes",
         "datasourceId",
+        "diseaseFromSource",
+        "studyId",
+        "studyOverview",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -606,7 +606,6 @@
       "required": [
         "cohortPhenotypes",
         "datasourceId",
-        "diseaseFromSource",
         "studyId",
         "studyOverview",
         "targetFromSourceId"
@@ -896,7 +895,6 @@
       "required": [
         "biologicalModelAllelicComposition",
         "biologicalModelGeneticBackground",
-        "biologicalModelId",
         "datasourceId",
         "diseaseFromSource",
         "diseaseModelAssociatedModelPhenotypes",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1048,6 +1048,9 @@
       },
       "required": [
         "datasourceId",
+        "diseaseFromSource",
+        "pathways",
+        "resourceScore",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -184,7 +184,11 @@
         }
       },
       "required": [
+        "allelicRequirements",
+        "confidence",
+        "diseaseFromSource",
         "datasourceId",
+        "studyId",
         "targetFromSourceId"
       ],
       "additionalProperties": false
@@ -1141,6 +1145,7 @@
       "items": {
         "type": "string"
       },
+      "minItems": 1,
       "uniqueItems": true
     },
     "beta": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1700,6 +1700,7 @@
             ]
           }
         },
+        "required": ["name"],
         "additionalProperties": false
       },
       "minItems": 1,

--- a/opentargets.json
+++ b/opentargets.json
@@ -381,8 +381,15 @@
         }
       },
       "required": [
+        "clinicalSignificances",
+        "cohortPhenotypes",
+        "confidence",
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "literature",
+        "studyId",
+        "targetFromSourceId",
+        "variantFunctionalConsequenceId"
       ],
       "additionalProperties": false
     },
@@ -1353,6 +1360,7 @@
           "uncertain significance"
         ]
       },
+      "minItems": 1,
       "uniqueItems": true
     },
     "clinicalStatus": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -1017,6 +1017,8 @@
       },
       "required": [
         "datasourceId",
+        "diseaseFromSource",
+        "pathways",
         "targetFromSourceId"
       ],
       "additionalProperties": false
@@ -1543,10 +1545,10 @@
             ]
           }
         },
-        "minItems": 1,
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": ["id"]
       },
-      "required": ["id"],
+      "minItems": 1,
       "uniqueItems": true
     },
     "drugFromSource": {
@@ -1669,6 +1671,7 @@
         "required": ["id"],
         "additionalProperties": false
       },
+      "minItems": 1,
       "uniqueItems": true
     },
     "pmcIds": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -797,7 +797,15 @@
       },
       "required": [
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "projectId",
+        "pValueExponent",
+        "pValueMantissa",
+        "resourceScore",
+        "studyId",
+        "targetFromSourceId",
+        "variantFunctionalConsequenceId",
+        "variantId"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -868,8 +868,16 @@
         }
       },
       "required": [
+        "biologicalModelAllelicComposition",
+        "biologicalModelGeneticBackground",
+        "biologicalModelId",
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "diseaseModelAssociatedModelPhenotypes",
+        "resourceScore",
+        "targetFromSourceId",
+        "targetInModel",
+        "targetInModelMgiId"
       ],
       "additionalProperties": false
     },
@@ -1525,8 +1533,10 @@
             ]
           }
         },
+        "minItems": 1,
         "additionalProperties": false
       },
+      "required": ["id"],
       "uniqueItems": true
     },
     "drugFromSource": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -147,8 +147,12 @@
         }
       },
       "required": [
+        "clinicalPhase",
         "datasourceId",
-        "targetFromSourceId"
+        "drugId",
+        "targetFromSource",
+        "targetFromSourceId",
+        "urls"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -41,9 +41,6 @@
         },
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
-        },
-        "urls": {
-          "$ref": "#/definitions/urls"
         }
       },
       "required": [
@@ -195,7 +192,8 @@
         "diseaseFromSource",
         "datasourceId",
         "studyId",
-        "targetFromSourceId"
+        "targetFromSourceId",
+        "urls"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1158,8 +1158,12 @@
         }
       },
       "required": [
+        "confidence",
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "literature",
+        "targetFromSourceId",
+        "targetModulation"
       ],
       "additionalProperties": false
     },
@@ -1208,7 +1212,9 @@
         "diseaseFromSource",
         "literature",
         "targetFromSourceId",
-        "targetModulation"
+        "targetModulation",
+        "variantFunctionalConsequenceId",
+        "variantRsId"
       ],
       "additionalProperties": false
     }

--- a/opentargets.json
+++ b/opentargets.json
@@ -1714,6 +1714,7 @@
         "pattern": "^PMC\\d+$",
         "description": "Literature identifer in PubMed Central"
       },
+      "minItems": 1,
       "uniqueItems": true
     },
     "projectId":{

--- a/opentargets.json
+++ b/opentargets.json
@@ -48,6 +48,8 @@
       },
       "required": [
         "datasourceId",
+        "mutatedSamples",
+        "resourceScore",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -1701,7 +1701,6 @@
             ]
           }
         },
-        "required": ["id"],
         "additionalProperties": false
       },
       "minItems": 1,

--- a/opentargets.json
+++ b/opentargets.json
@@ -620,7 +620,12 @@
         }
       },
       "required": [
+        "cohortDescription",
+        "cohortId",
+        "cohortShortName",
         "datasourceId",
+        "diseaseFromSource",
+        "mutatedSamples",
         "targetFromSourceId"
       ],
       "additionalProperties": false
@@ -1568,12 +1573,7 @@
         "type": "object",
         "properties": {
           "functionalConsequenceId": {
-            "type": "string",
-            "description": "Sequence ontology (SO) identifier of the functional consequence of the variant",
-            "pattern": "SO_\\d+",
-            "examples": [
-              "SO_0001628"
-            ]
+            "$ref": "#/definitions/variantFunctionalConsequenceId"
           },
           "numberMutatedSamples": {
             "type": "integer",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1886,13 +1886,18 @@
           "section": {
             "type": "string",
             "description": "Section in which sentence occurs",
-            "examples": [
+            "enum": [
               "title",
-              "table",
-              "other",
+              "abstract",
+              "intro",
+              "case",
               "figure",
+              "table",
+              "discuss",
+              "concl",
+              "results",
               "appendix",
-              "abstract"
+              "other"
             ]
           },
           "tEnd": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -221,6 +221,9 @@
       },
       "required": [
         "datasourceId",
+        "diseaseCellLines",
+        "diseaseFromSource",
+        "resourceScore",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -530,7 +530,10 @@
         }
       },
       "required": [
+        "confidence",
         "datasourceId",
+        "diseaseFromSource",
+        "studyId",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -917,7 +917,13 @@
       },
       "required": [
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSource",
+        "oddsRatio",
+        "resourceScore",
+        "studyCases",
+        "targetFromSourceId",
+        "variantFunctionalConsequenceId",
+        "variantRsId"
       ],
       "additionalProperties": false
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1090,6 +1090,11 @@
       },
       "required": [
         "datasourceId",
+        "diseaseFromSource",
+        "literature",
+        "pathways",
+        "resourceScore",
+        "studyOverview",
         "targetFromSourceId"
       ],
       "additionalProperties": false

--- a/opentargets.json
+++ b/opentargets.json
@@ -261,7 +261,10 @@
       },
       "required": [
         "datasourceId",
-        "targetFromSourceId"
+        "diseaseFromSourceMappedId",
+        "resourceScore",
+        "targetFromSourceId",
+        "textMiningSentences"
       ],
       "additionalProperties": false
     },
@@ -1822,6 +1825,14 @@
             "description": "Index position where target name starts in sentence"
           }
         },
+        "required": [
+          "dEnd",
+          "dStart",
+          "section",
+          "tEnd",
+          "text",
+          "tStart"
+        ],
         "additionalProperties": false
       },
       "uniqueItems": true


### PR DESCRIPTION
This PR closes [#1823](https://github.com/opentargets/platform/issues/1823).

- All data sources except `encore` and `ot_crispr` have been analysed and have their schemas changed.
- I've added the restriction of an array not being empty for: `allelicRequirements`, `pathway`, `diseaseModelAssociatedModelPhenotypes`, `clinicalSignificances`.

To review this PR, I would suggest using this schema to validate the evidence we are currently reviewing.

Some questions:
1. I thought the PMCIDs were covering the gaps where but there is no EPMC evidence without a PMID. Is this expected? @DSuveges 
2. `pmcId` can contain an empty array. Should we ask EPMC to nullify it instead? @DSuveges 