### PR TITLE
Remove literature from required field in EVA schema

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -386,7 +386,6 @@
         "confidence",
         "datasourceId",
         "diseaseFromSource",
-        "literature",
         "studyId",
         "targetFromSourceId",
         "variantFunctionalConsequenceId"


### PR DESCRIPTION
April from EVA has reported that she is unable to validate the evidence strings for their new submission.

After looking at the offending strings, they all belong to `eva` and fail validation because some of them lack the `literature` field that I introduced as required in the PR where the JSON schema became more rigid.

As a note, [RCV000690560](https://www.ncbi.nlm.nih.gov/clinvar/RCV000690560/?redir=rcv) is an example of an evidence string without a literature reference. I am not sure which fields EVA picks as reference, but both the SCV and evidence tab link to a publication. I've asked April about it but I think it still makes sense to flex the schema for now.

