### PR TITLE
Add studyStopReasonCategories to ChEMBL schema

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -133,6 +133,9 @@
         "studyStopReason": {
           "$ref": "#/definitions/studyStopReason"
         },
+        "studyStopReasonCategories": {
+          "$ref": "#/definitions/studyStopReasonCategories"
+        },
         "targetFromSource": {
           "$ref": "#/definitions/targetFromSourceId"
         },
@@ -1826,6 +1829,33 @@
       "type": "string",
       "description": "Reason why a study has been stopped",
       "pattern": "^[^\\ ].*[^\\ ]$"
+    },
+    "studyStopReasonCategories": {
+      "type": "array",
+      "description": "Assigned category to the reason why a study has been stopped.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Insufficient_Enrollment",
+          "Business_Administrative",
+          "Negative",
+          "Logistics_Resources",
+          "Study_Design",
+          "Invalid_Reason",
+          "Study_Staff_Moved",
+          "Covid19",
+          "Another_Study",
+          "No_Context",
+          "Safety_Sideeffects",
+          "Regulatory",
+          "Interim_Analysis",
+          "Success",
+          "Endpoint_Met",
+          "Ethical_Reason",
+          "Insufficient_Data"
+        ]
+      },
+      "uniqueItems": true
     },
     "targetFromSourceId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1832,7 +1832,7 @@
     },
     "studyStopReasonCategories": {
       "type": "array",
-      "description": "Assigned category to the reason why a study has been stopped.",
+      "description": "Predicted reason(s) why the study has been stopped based on studyStopReason.",
       "items": {
         "type": "string",
         "enum": [

--- a/opentargets.json
+++ b/opentargets.json
@@ -1836,23 +1836,23 @@
       "items": {
         "type": "string",
         "enum": [
-          "Insufficient_Enrollment",
-          "Business_Administrative",
+          "Insufficient enrollment",
+          "Business or administrative",
           "Negative",
-          "Logistics_Resources",
-          "Study_Design",
-          "Invalid_Reason",
-          "Study_Staff_Moved",
-          "Covid19",
-          "Another_Study",
-          "No_Context",
-          "Safety_Sideeffects",
+          "Logistics or resources",
+          "Study design",
+          "Invalid reason",
+          "Study staff moved",
+          "COVID-19",
+          "Another study",
+          "No context",
+          "Safety or side effects",
           "Regulatory",
-          "Interim_Analysis",
+          "Interim analysis",
           "Success",
-          "Endpoint_Met",
-          "Ethical_Reason",
-          "Insufficient_Data"
+          "Met endpoint",
+          "Ethical reason",
+          "Insufficient data"
         ]
       },
       "uniqueItems": true


### PR DESCRIPTION
Follow up from [#1878](https://github.com/opentargets/platform/issues/1878).

~I am tagging it as a draft PR pending confirmation of the part of the pipeline in which the new scoring will be implemented.~ Score will continue to happen in the ETL, so no `resourceScore` is needed.