### PR TITLE
Schema definitions for the evidence sets for the partner instance

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -259,6 +259,9 @@
         "diseaseFromSourceMappedId": {
           "ref": "#/definitions/diseaseFromSourceMappedId"
         },
+        "geneInteractionType": {
+          "ref": "#/definitions/geneInteractionType"
+        },
         "geneticInteractionFDR": {
           "ref": "#/definitions/geneticInteractionFDR"
         },
@@ -341,63 +344,6 @@
         "resourceScore",
         "targetFromSourceId",
         "textMiningSentences"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "datasourceId": {
-          "const": "encore"
-        },
-        "cellType" : {
-          "$ref": "#/definitions/cellType"
-        },
-        "datatypeId" : {
-          "$ref": "#/definitions/datatypeId"
-        },
-        "diseaseCellLines" : {
-          "$ref": "#/definitions/diseaseCellLines"
-        },
-        "diseaseFromSource" : {
-          "$ref": "#/definitions/diseaseFromSource"
-        },
-        "diseaseFromSourceMappedId" : {
-          "$ref": "#/definitions/diseaseFromSourceMappedId"
-        },
-        "geneticInteractionFDR" : {
-          "$ref": "#/definitions/falseDiscoveryRate"
-        },
-        "geneticInteractionMethod" : {
-          "$ref": "#/definitions/geneticInteractionMethod"
-        },
-        "geneticInteractionPValue" : {
-          "$ref": "#/definitions/pValue"
-        },
-        "geneticInteractionScore" : {
-          "$ref": "#/definitions/geneticInteractionScore"
-        },
-        "interactingTargetFromSourceId" : {
-          "$ref": "#/definitions/targetFromSourceId"
-        },
-        "phenotypicConsequenceFDR" : {
-          "$ref": "#/definitions/falseDiscoveryRate"
-        },
-        "phenotypicConsequenceLogFoldChange" : {
-          "$ref": "#/definitions/log2FoldChangeValue"
-        },
-        "phenotypicConsequencePValue" : {
-          "$ref": "#/definitions/pValue"
-        },
-        "projectId" : {
-          "$ref": "#/definitions/projectId"
-        },
-        "targetFromSourceId" : {
-          "$ref": "#/definitions/targetFromSourceId"
-        }
-      },
-      "required": [
-        "datasourceId",
-        "targetFromSourceId"
       ],
       "additionalProperties": false
     },
@@ -830,8 +776,7 @@
         "projectDescription",
         "resourceScore",
         "studyOverview",
-        "studyId",
-        "targetFromSourceId"
+        "studyId"
       ],
       "additionalProperties": false
     },
@@ -1715,6 +1660,13 @@
       "minimum": 0.0,
       "maximum": 1.0
     },
+    "geneInteractionType": {
+      "type": "string",
+      "description": "Description of the interaction between the two genes",
+      "examples": [
+        "cooperative"
+      ]
+    },
     "geneticBackground": {
       "type": "string",
       "description": "Additional genetic background of the applied cell line in the CRISPR screen."
@@ -1870,7 +1822,7 @@
     },
     "projectDescription": {
       "type": "string",
-      "description": "Description of the project that generated the data.",
+      "description": "Description of the project that generated the data."
     },
     "pValue": {
       "type": "number",
@@ -2012,14 +1964,15 @@
         "ENSG00000012048",
         "P38398"
       ],
-      "pattern": "^[A-Z0-9]$"
+      "pattern": "^[A-Z0-9]+$"
     },
     "targetFromSource": {
       "type": "string",
       "description": "Target name/synonym or non HGNC symbol in resource of origin",
       "examples": [
         "3-mercaptopyruvate sulfurtransferase"
-      ]
+      ],
+      "pattern": "^[A-Z0-9]+$"
     },
     "targetInModelEnsemblId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -242,6 +242,75 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "encore"
+        },
+        "biomarkerList": {
+          "ref": "#/definitions/biomarkerList"
+        },
+        "datatypeId": {
+          "ref": "#/definitions/datatypeId"
+        },
+        "diseaseCellLines": {
+          "ref": "#/definitions/diseaseCellLines"
+        },
+        "diseaseFromSource": {
+          "ref": "#/definitions/diseaseFromSource"
+        },
+        "diseaseFromSourceMappedId": {
+          "ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "geneticInteractionFDR": {
+          "ref": "#/definitions/geneticInteractionFDR"
+        },
+        "geneticInteractionMethod": {
+          "ref": "#/definitions/geneticInteractionMethod"
+        },
+        "geneticInteractionPValue": {
+          "ref": "#/definitions/geneticInteractionPValue"
+        },
+        "geneticInteractionScore": {
+          "ref": "#/definitions/geneticInteractionScore"
+        },
+        "interactingTargetFromSourceId": {
+          "ref": "#/definitions/interactingTargetFromSourceId"
+        },
+        "interactingTargetRole": {
+          "ref": "#/definitions/interactingTargetFromRole"
+        },
+        "phenotypicConsequenceFDR": {
+          "ref": "#/definitions/phenotypicConsequenceFDR"
+        },
+        "phenotypicConsequenceLogFoldChange": {
+          "ref": "#/definitions/phenotypicConsequenceLogFoldChange"
+        },
+        "phenotypicConsequencePValue": {
+          "ref": "#/definitions/phenotypicConsequencePValue"
+        },
+        "projectDescription": {
+          "ref": "#/definitions/projectDescription"
+        },
+        "projectId": {
+          "ref": "#/definitions/projectId"
+        },
+        "targetFromSourceId": {
+          "ref": "#/definitions/targetFromSourceId"
+        },
+        "targetRole": {
+          "ref": "#/definitions/targetRole"
+        }
+      },
+      "required": [
+        "datasourceId",
+        "datatypeId",
+        "diseaseFromSourceMappedId",
+        "targetFromSourceId",
+        "geneticInteractionScore"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "europepmc"
         },
         "datatypeId": {
@@ -1650,6 +1719,10 @@
       "type": "string",
       "description": "Additional genetic background of the applied cell line in the CRISPR screen."
     },
+    "geneticInteractionFDR": {
+      "type": "number",
+      "description": "False discovery rate of the genetic interaiton test"
+    },
     "geneticInteractionMethod": {
       "type": "string",
       "description": "The applied method calculating the genetic interaction between targets.",
@@ -1658,9 +1731,25 @@
         "bliss"
       ]
     },
+    "geneticInteractionPValue": {
+      "type": "number",
+      "description": "P-value of the genetic interaction test."
+    },
     "geneticInteractionScore": {
       "type": "number",
       "description": "The strength of the genetic interaction. Directionality is captured as well: antagonistics < 0 < cooperative."
+    },
+    "interactingTargetFromSourceId": {
+      "type": "string",
+      "description": "Target id of the interaction partner."
+    },
+    "interactingTargetRole": {
+      "type": "string",
+      "description": "Role of the partner in the genetic interaction test",
+      "examples": [
+        "Anchor",
+        "Library"
+      ]
     },
     "drugResponse": {
       "type": "string",
@@ -1746,6 +1835,18 @@
       },
       "minItems": 1,
       "uniqueItems": true
+    },
+    "phenotypicConsequenceFDR": {
+      "type": "number",
+      "description": "False discovery rate of the genetic test"
+    },
+    "phenotypicConsequenceLogFoldChange": {
+      "type": "number",
+      "description": "Log 2 fold change of the cell survival."
+    },
+    "phenotypicConsequencePValue": {
+      "type": "number",
+      "description": "P-value of the the cell survival test."
     },
     "pmcIds": {
       "type": "array",
@@ -1945,6 +2046,14 @@
     "targetModulation": {
       "type": "string",
       "description": "Description of target modulation event"
+    },
+    "targetRole": {
+      "type": "string",
+      "description": "Role of the target in the genetic interaction test.",
+      "examples": [
+        "library",
+        "Anchor"
+      ]
     },
     "textMiningSentences": {
       "type": "array",

--- a/opentargets.json
+++ b/opentargets.json
@@ -245,61 +245,61 @@
           "const": "encore"
         },
         "biomarkerList": {
-          "ref": "#/definitions/biomarkerList"
+          "$ref": "#/definitions/biomarkerList"
         },
         "datatypeId": {
-          "ref": "#/definitions/datatypeId"
+          "$ref": "#/definitions/datatypeId"
         },
         "diseaseCellLines": {
-          "ref": "#/definitions/diseaseCellLines"
+          "$ref": "#/definitions/diseaseCellLines"
         },
         "diseaseFromSource": {
-          "ref": "#/definitions/diseaseFromSource"
+          "$ref": "#/definitions/diseaseFromSource"
         },
         "diseaseFromSourceMappedId": {
-          "ref": "#/definitions/diseaseFromSourceMappedId"
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
         "geneInteractionType": {
-          "ref": "#/definitions/geneInteractionType"
+          "$ref": "#/definitions/geneInteractionType"
         },
         "geneticInteractionFDR": {
-          "ref": "#/definitions/geneticInteractionFDR"
+          "$ref": "#/definitions/geneticInteractionFDR"
         },
         "geneticInteractionMethod": {
-          "ref": "#/definitions/geneticInteractionMethod"
+          "$ref": "#/definitions/geneticInteractionMethod"
         },
         "geneticInteractionPValue": {
-          "ref": "#/definitions/geneticInteractionPValue"
+          "$ref": "#/definitions/geneticInteractionPValue"
         },
         "geneticInteractionScore": {
-          "ref": "#/definitions/geneticInteractionScore"
+          "$ref": "#/definitions/geneticInteractionScore"
         },
         "interactingTargetFromSourceId": {
-          "ref": "#/definitions/interactingTargetFromSourceId"
+          "$ref": "#/definitions/interactingTargetFromSourceId"
         },
         "interactingTargetRole": {
-          "ref": "#/definitions/interactingTargetFromRole"
+          "$ref": "#/definitions/targetRole"
         },
         "phenotypicConsequenceFDR": {
-          "ref": "#/definitions/phenotypicConsequenceFDR"
+          "$ref": "#/definitions/phenotypicConsequenceFDR"
         },
         "phenotypicConsequenceLogFoldChange": {
-          "ref": "#/definitions/phenotypicConsequenceLogFoldChange"
+          "$ref": "#/definitions/phenotypicConsequenceLogFoldChange"
         },
         "phenotypicConsequencePValue": {
-          "ref": "#/definitions/phenotypicConsequencePValue"
+          "$ref": "#/definitions/phenotypicConsequencePValue"
         },
         "projectDescription": {
-          "ref": "#/definitions/projectDescription"
+          "$ref": "#/definitions/projectDescription"
         },
         "projectId": {
-          "ref": "#/definitions/projectId"
+          "$ref": "#/definitions/projectId"
         },
         "targetFromSourceId": {
-          "ref": "#/definitions/targetFromSourceId"
+          "$ref": "#/definitions/targetFromSourceId"
         },
         "targetRole": {
-          "ref": "#/definitions/targetRole"
+          "$ref": "#/definitions/targetRole"
         }
       },
       "required": [
@@ -688,7 +688,7 @@
           "$ref": "#/definitions/confidence"
         },
         "datatypeId": {
-          "ref": "#/definitions/datatypeId"
+          "$ref": "#/definitions/datatypeId"
         },
         "diseaseFromSource": {
           "$ref": "#/definitions/diseaseFromSource"
@@ -786,53 +786,56 @@
           "const": "ot_crispr_validation"
         },
         "biomarkerList": {
-          "ref": "#/definitions/biomarkerList"
+          "$ref": "#/definitions/biomarkerList"
         },
         "confidence": {
-          "ref": "#/definitions/confidence"
+          "$ref": "#/definitions/confidence"
         },
         "contrast": {
-          "ref": "#/definitions/contrast"
+          "$ref": "#/definitions/contrast"
         },
         "datatypeId": {
-          "ref": "#/definitions/datatypeId"
+          "$ref": "#/definitions/datatypeId"
         },
         "diseaseCellLines": {
-          "ref": "#/definitions/diseaseCellLines"
+          "$ref": "#/definitions/diseaseCellLines"
         },
         "diseaseFromSource": {
-          "ref": "#/definitions/diseaseFromSource"
+          "$ref": "#/definitions/diseaseFromSource"
         },
         "diseaseFromSourceMappedId": {
-          "ref": "#/definitions/diseaseFromSourceMappedId"
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
         "expectedConfidence": {
-          "ref": "#/definitions/expectedConfidence"
+          "$ref": "#/definitions/expectedConfidence"
         },
         "projectDescription": {
-          "ref": "#/definitions/projectDescription"
+          "$ref": "#/definitions/projectDescription"
         },
         "projectId": {
-          "ref": "#/definitions/projectId"
+          "$ref": "#/definitions/projectId"
         },
         "resourceScore": {
-          "ref": "#/definitions/resourceScore"
+          "$ref": "#/definitions/resourceScore"
         },
         "statisticalTestTail": {
-          "ref": "#/definitions/statisticalTestTail"
+          "$ref": "#/definitions/statisticalTestTail"
         },
         "studyOverview": {
-          "ref": "#/definitions/studyOverview"
+          "$ref": "#/definitions/studyOverview"
         },
         "targetFromSourceId": {
-          "ref": "#/definitions/targetFromSourceId"
+          "$ref": "#/definitions/targetFromSourceId"
         },
         "validationHypotheses": {
-          "ref": "#/definitions/validationHypotheses"
+          "$ref": "#/definitions/validationHypotheses"
         }
       },
       "required": [
-        
+        "datasourceId",
+        "datatypeId",
+        "targetFromSourceId",
+        "diseaseFromSourceMappedId"
       ],
       "additionalProperties": false
     },
@@ -1663,8 +1666,9 @@
     "geneInteractionType": {
       "type": "string",
       "description": "Description of the interaction between the two genes.",
-      "examples": [
-        "cooperative"
+      "enum": [
+        "cooperative",
+        "additive"
       ]
     },
     "geneticBackground": {
@@ -1678,7 +1682,7 @@
     "geneticInteractionMethod": {
       "type": "string",
       "description": "The applied method calculating the genetic interaction between targets.",
-      "examples": [
+      "enum": [
         "gemini",
         "bliss"
       ]
@@ -1694,14 +1698,6 @@
     "interactingTargetFromSourceId": {
       "type": "string",
       "description": "Target id of the interaction partner."
-    },
-    "interactingTargetRole": {
-      "type": "string",
-      "description": "Role of the partner in the genetic interaction test",
-      "examples": [
-        "Anchor",
-        "Library"
-      ]
     },
     "drugResponse": {
       "type": "string",
@@ -1900,7 +1896,7 @@
     "statisticalTestTail": {
       "type": "string",
       "description": "Which end of the distribution the target was picked from.",
-      "examples": [
+      "enum": [
         "upper tail",
         "lower tail"
       ]
@@ -2002,10 +1998,11 @@
     },
     "targetRole": {
       "type": "string",
-      "description": "Role of the target in the genetic interaction test.",
-      "examples": [
+      "description": "Role of a target in the genetic interaction test.",
+      "enum": [
         "library",
-        "Anchor"
+        "anchor",
+        "gicontrols"
       ]
     },
     "textMiningSentences": {

--- a/opentargets.json
+++ b/opentargets.json
@@ -769,6 +769,62 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "ot_crispr_validation"
+        },
+        "biomarkerList": {
+          "ref": "#/definitions/biomarkerList"
+        },
+        "confidence": {
+          "ref": "#/definitions/confidence"
+        },
+        "contrast": {
+          "ref": "#/definitions/contrast"
+        },
+        "datatypeId": {
+          "ref": "#/definitions/datatypeId"
+        },
+        "diseaseCellLines": {
+          "ref": "#/definitions/diseaseCellLines"
+        },
+        "diseaseFromSource": {
+          "ref": "#/definitions/diseaseFromSource"
+        },
+        "diseaseFromSourceMappedId": {
+          "ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "expectedConfidence": {
+          "ref": "#/definitions/expectedConfidence"
+        },
+        "projectDescription": {
+          "ref": "#/definitions/projectDescription"
+        },
+        "projectId": {
+          "ref": "#/definitions/projectId"
+        },
+        "resourceScore": {
+          "ref": "#/definitions/resourceScore"
+        },
+        "statisticalTestTail": {
+          "ref": "#/definitions/statisticalTestTail"
+        },
+        "studyOverview": {
+          "ref": "#/definitions/studyOverview"
+        },
+        "targetFromSourceId": {
+          "ref": "#/definitions/targetFromSourceId"
+        },
+        "validationHypotheses": {
+          "ref": "#/definitions/validationHypotheses"
+        }
+      },
+      "required": [
+        
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "ot_genetics_portal"
         },
         "beta": {
@@ -1242,6 +1298,34 @@
         "BRAF (V600E,V600D,V600K,V600M,V600G,V600R)"
       ]
     },
+    "biomarkerList": {
+      "type": "array",
+      "description": "List of biomarkers associated with the biological model.",
+      "items":{
+        "type": "object",
+        "description": "One biomarker for the model",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Short name of the biomarker.",
+            "examples": [
+              "MSI"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the biomarker",
+            "examples": [
+              "Microsatellite instable"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": true
+      }
+    },
     "biomarkers": {
       "type": "object",
       "description": "List of biomarkers.",
@@ -1548,6 +1632,12 @@
       "examples": [
         "CHEMBL1431",
         "CHEMBL803"
+      ]
+    },
+    "expectedConfidence": {
+      "type": "string",
+      "examples": [
+        "significant"
       ]
     },
     "falseDiscoveryRate": {
@@ -1954,6 +2044,48 @@
         "additionalProperties": false
       },
       "uniqueItems": true
+    },
+    "validationHypotheses": {
+      "type": "array",
+      "description": "List of tested hypotheses and the outcome of the test.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the tested hypothesis",
+            "examples": [
+              "APC-wt"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the tested hypothesis.",
+            "examples": [
+              "APC mutation status: wild type"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the validation in context of the original experiment.",
+            "examples": [
+              "expected but not observed"
+            ],
+            "enum": [
+              "expected but not observed",
+              "not expected and not observed",
+              "observed and expected",
+              "observed but not expected"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "status"
+        ],
+        "additionalProperties": false
+      }
     },
     "variantFunctionalConsequenceId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1971,8 +1971,7 @@
       "description": "Target name/synonym or non HGNC symbol in resource of origin",
       "examples": [
         "3-mercaptopyruvate sulfurtransferase"
-      ],
-      "pattern": "^[A-Z0-9]+$"
+      ]
     },
     "targetInModelEnsemblId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -265,8 +265,8 @@
         "geneticInteractionFDR": {
           "$ref": "#/definitions/geneticInteractionFDR"
         },
-        "geneticInteractionMethod": {
-          "$ref": "#/definitions/geneticInteractionMethod"
+        "statisticalMethod": {
+          "$ref": "#/definitions/statisticalMethod"
         },
         "geneticInteractionPValue": {
           "$ref": "#/definitions/geneticInteractionPValue"
@@ -1674,14 +1674,6 @@
       "type": "number",
       "description": "False discovery rate of the genetic interaction test."
     },
-    "geneticInteractionMethod": {
-      "type": "string",
-      "description": "The applied method calculating the genetic interaction between targets.",
-      "enum": [
-        "gemini",
-        "bliss"
-      ]
-    },
     "geneticInteractionPValue": {
       "type": "number",
       "description": "P-value of the genetic interaction test."
@@ -1883,6 +1875,13 @@
         ]
       },
       "uniqueItems": true
+    },
+    "statisticalMethod": {
+      "type": "string",
+      "description": "The statistical method used to analyse data.",
+      "examples": [
+        "BLISS"
+      ]
     },
     "statisticalTestTail": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1876,13 +1876,6 @@
       },
       "uniqueItems": true
     },
-    "statisticalMethod": {
-      "type": "string",
-      "description": "The statistical method used to analyse data.",
-      "examples": [
-        "BLISS"
-      ]
-    },
     "statisticalTestTail": {
       "type": "string",
       "description": "End of the distribution the target was picked from.",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1662,7 +1662,7 @@
     },
     "geneInteractionType": {
       "type": "string",
-      "description": "Description of the interaction between the two genes",
+      "description": "Description of the interaction between the two genes.",
       "examples": [
         "cooperative"
       ]
@@ -1673,7 +1673,7 @@
     },
     "geneticInteractionFDR": {
       "type": "number",
-      "description": "False discovery rate of the genetic interaiton test"
+      "description": "False discovery rate of the genetic interaction test."
     },
     "geneticInteractionMethod": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -909,60 +909,6 @@
     {
       "properties": {
         "datasourceId": {
-          "const": "phewas_catalog"
-        },
-        "datatypeId": {
-          "$ref": "#/definitions/datatypeId"
-        },
-        "diseaseFromSource": {
-          "$ref": "#/definitions/diseaseFromSource"
-        },
-        "diseaseFromSourceId": {
-          "$ref": "#/definitions/diseaseFromSourceId"
-        },
-        "oddsRatio": {
-          "$ref": "#/definitions/oddsRatio"
-        },
-        "resourceScore": {
-          "$ref": "#/definitions/resourceScore"
-        },
-        "studyCases": {
-          "$ref": "#/definitions/studyCases"
-        },
-        "targetFromSourceId": {
-          "$ref": "#/definitions/targetFromSourceId"
-        },
-        "targetFromSource": {
-          "$ref": "#/definitions/targetFromSource"
-        },
-        "variantFunctionalConsequenceId": {
-          "$ref": "#/definitions/variantFunctionalConsequenceId"
-        },
-        "variantId": {
-          "$ref": "#/definitions/variantId"
-        },
-        "variantRsId": {
-          "$ref": "#/definitions/variantRsId"
-        },
-        "diseaseFromSourceMappedId": {
-          "$ref": "#/definitions/diseaseFromSourceMappedId"
-        }
-      },
-      "required": [
-        "datasourceId",
-        "diseaseFromSource",
-        "oddsRatio",
-        "resourceScore",
-        "studyCases",
-        "targetFromSourceId",
-        "variantFunctionalConsequenceId",
-        "variantRsId"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "properties": {
-        "datasourceId": {
           "const": "progeny"
         },
         "datatypeId": {
@@ -1800,11 +1746,6 @@
         ]
       },
       "uniqueItems": true
-    },
-    "studyCases": {
-      "type": "integer",
-      "description": "Number of cases in case-control study",
-      "exclusiveMinimum": 0
     },
     "studyId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -275,7 +275,7 @@
           "$ref": "#/definitions/geneticInteractionScore"
         },
         "interactingTargetFromSourceId": {
-          "$ref": "#/definitions/interactingTargetFromSourceId"
+          "$ref": "#/definitions/targetFromSourceId"
         },
         "interactingTargetRole": {
           "$ref": "#/definitions/targetRole"
@@ -807,7 +807,7 @@
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
         "expectedConfidence": {
-          "$ref": "#/definitions/expectedConfidence"
+          "$ref": "#/definitions/confidence"
         },
         "projectDescription": {
           "$ref": "#/definitions/projectDescription"
@@ -1340,7 +1340,7 @@
         "required": [
           "name"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       }
     },
     "biomarkers": {
@@ -1651,12 +1651,6 @@
         "CHEMBL803"
       ]
     },
-    "expectedConfidence": {
-      "type": "string",
-      "examples": [
-        "significant"
-      ]
-    },
     "falseDiscoveryRate": {
       "type": "number",
       "description": "False discovery rate (FDR) captures the rate of type I error.",
@@ -1694,10 +1688,6 @@
     "geneticInteractionScore": {
       "type": "number",
       "description": "The strength of the genetic interaction. Directionality is captured as well: antagonistics < 0 < cooperative."
-    },
-    "interactingTargetFromSourceId": {
-      "type": "string",
-      "description": "Target id of the interaction partner."
     },
     "drugResponse": {
       "type": "string",
@@ -1895,7 +1885,7 @@
     },
     "statisticalTestTail": {
       "type": "string",
-      "description": "Which end of the distribution the target was picked from.",
+      "description": "End of the distribution the target was picked from.",
       "enum": [
         "upper tail",
         "lower tail"

--- a/opentargets.json
+++ b/opentargets.json
@@ -2006,12 +2006,13 @@
     },
     "targetFromSourceId": {
       "type": "string",
-      "description": "Target ID in resource of origin (accepted sources include Ensembl gene ID, Uniprot ID, gene symbol)",
+      "description": "Target ID in resource of origin (accepted sources include Ensembl gene ID, Uniprot ID, gene symbol), only capital letters are accepted.",
       "examples": [
         "BRCA1",
         "ENSG00000012048",
         "P38398"
-      ]
+      ],
+      "pattern": "^[A-Z0-9]$"
     },
     "targetFromSource": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -723,14 +723,20 @@
         "datatypeId": {
           "$ref": "#/definitions/datatypeId"
         },
-        "direction": {
-          "$ref": "#/definitions/direction"
+        "statisticalTestTail": {
+          "$ref": "#/definitions/statisticalTestTail"
         },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
         "geneticBackground": {
           "$ref": "#/definitions/geneticBackground"
+        },
+        "log2FoldChangeValue": {
+          "$ref": "#/definitions/log2FoldChangeValue"
+        },
+        "projectDescription": {
+          "$ref": "#/definitions/projectDescription"
         },
         "projectId": {
           "$ref": "#/definitions/projectId"
@@ -750,6 +756,12 @@
       },
       "required": [
         "datasourceId",
+        "targetFromSourceId",
+        "projectId",
+        "projectDescription",
+        "resourceScore",
+        "studyOverview",
+        "studyId",
         "targetFromSourceId"
       ],
       "additionalProperties": false
@@ -1416,15 +1428,6 @@
         "ot_partner"
       ]
     },
-    "direction": {
-      "type": "string",
-      "description": "Which end of the distribution the target was picked from.",
-      "examples": [
-        "upper tail",
-        "lower tail"
-      ]
-
-    },
     "diseaseCellLines": {
       "type": "array",
       "description": "Cancer cell lines used to generate evidence",
@@ -1674,6 +1677,10 @@
         "OTAR033"
       ]
     },
+    "projectDescription": {
+      "type": "string",
+      "description": "Description of the project that generated the data.",
+    },
     "pValue": {
       "type": "number",
       "description": "p-value",
@@ -1746,6 +1753,14 @@
         ]
       },
       "uniqueItems": true
+    },
+    "statisticalTestTail": {
+      "type": "string",
+      "description": "Which end of the distribution the target was picked from.",
+      "examples": [
+        "upper tail",
+        "lower tail"
+      ]
     },
     "studyId": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1526,7 +1526,8 @@
         "somatic_mutation",
         "known_drug",
         "genetic_association",
-        "ot_partner"
+        "ot_partner",
+        "ot_validation_lab"
       ]
     },
     "diseaseCellLines": {


### PR DESCRIPTION
Changes covered in ticket [#1966](https://github.com/opentargets/platform/issues/1966).

The following updates were added:
* Support for Encore evidence
* Support for validation lab evidence
* Updated support for ot_crispr
* Removed support for PheWAS catalog
* Enforced capitalization

**Validates validation lab evidence:**

```json
{
  "targetFromSourceId": "target1",
  "validationHypotheses": [
    {
      "name": "CRIS-D",
      "description": "WNT activation, IGF2 gene overexpression and amplification.",
      "status": "not expected and not observed"
    },
    {
      "name": "APC-wt",
      "description": "APC mutation status: wild type",
      "status": "not expected and not observed"
    },
    {
      "name": "MSI",
      "description": "Microsatellite instable",
      "status": "not expected and not observed"
    },
    {
      "name": "CRIS-?",
      "description": "CRIS subtype undetermined.",
      "status": "not expected and not observed"
    },
    {
      "name": "APC-mut",
      "description": "APC mutation status: mutant",
      "status": "not expected and not observed"
    },
    {
      "name": "MSS",
      "description": "Microsatellite stable",
      "status": "not expected and not observed"
    },
    {
      "name": "KRAS-mut",
      "description": "KRAS mutation status: mutant",
      "status": "not expected and not observed"
    },
    {
      "name": "TP53-mut",
      "description": "TP53 mutation status: mutant",
      "status": "not expected and not observed"
    },
    {
      "name": "TP53-wt",
      "description": "TP53 mutation status: wild type",
      "status": "not expected and not observed"
    },
    {
      "name": "CRIS-A",
      "description": "mucinous, glycolytic, enriched for microsatellite instability or KRAS mutations.",
      "status": "not expected and not observed"
    },
    {
      "name": "CRIS-B",
      "description": "TGF-β pathway activity, epithelial-mesenchymal transition, poor prognosis.",
      "status": "not expected and not observed"
    },
    {
      "name": "KRAS-wt",
      "description": "KRAS mutation status: wild type",
      "status": "not expected and not observed"
    },
    {
      "name": "PAN-CO",
      "description": "Pan-colorectal carcinoma",
      "status": "observed but not expected\""
    }
  ],
  "resourceScore": 0.00,
  "confidence": "significant",
  "expectedConfidence": "not significant",
  "statisticalTestTail": "upper tail",
  "contrast": "Loss of cell viability vs control",
  "studyOverview": "CellTtreGio measurement",
  "datasourceId": "ot_crispr_validation",
  "datatypeId": "ot_validation_lab",
  "diseaseFromSourceMappedId": "EFO_0000001",
  "diseaseFromSource": "disease 1",
  "projectId": "OTAR015",
  "projectDescription": "CRISPR Cas9 Target ID",
  "biomarkerList": [
    {
      "name": "MSS",
      "description": "Microsatellite stable"
    },
    {
      "name": "CRIS-?",
      "description": "CRIS subtype undetermined."
    },
    {
      "name": "KRAS-mut",
      "description": "KRAS mutation status: mutant"
    },
    {
      "name": "TP53-mut",
      "description": "TP53 mutation status: mutant"
    },
    {
      "name": "APC-mut",
      "description": "APC mutation status: mutant"
    }
  ],
  "diseaseCellLines": [
    {
      "name": "SW626",
      "id": "SIDM01168",
      "tissue": "Large Intestine",
      "tissueId": "UBERON_0000059"
    }
  ]
}
```

**Validates the following encore evidence:**

```json
{
  "phenotypicConsequenceLogFoldChange": -1.5397,
  "phenotypicConsequencePValue": 0.013659,
  "phenotypicConsequenceFDR": 0.206093,
  "geneticInteractionScore": 0.9929675,
  "geneticInteractionPValue": 0.048499946,
  "geneticInteractionFDR": 0.24703196,
  "geneticInteractionMethod": "gemini",
  "diseaseCellLines": [
    {
      "tissue": "Large Intestine",
      "name": "LoVo",
      "id": "SIDM00839",
      "tissueId": "UBERON_0000059"
    }
  ],
  "biomarkerList": [
    {
      "name": "MSI",
      "description": "Microsatellite instable"
    }
  ],
  "targetFromSourceId": "MYC",
  "targetRole": "anchor",
  "interactingTargetFromSourceId": "ABCB1",
  "interactingTargetRole": "library",
  "datatypeId": "ot_partner",
  "datasourceId": "encore",
  "projectId": "OTAR2062",
  "projectDescription": "Encore project",
  "geneInteractionType": "cooperative",
  "diseaseFromSourceMappedId": "EFO_1001951",
  "diseaseFromSource": "colorectal carcinoma"
}
```

**Validates the following ot-crispr evidence:**

```json
{
  "targetFromSourceId": "YIF1B",
  "diseaseFromSourceMappedId": "EFO_0000249",
  "projectDescription": "iPSC neuron CRISPR",
  "projectId": "OTAR036",
  "studyId": "OTAR036_TAU_uptake_1",
  "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein",
  "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)",
  "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)",
  "cellType": "iPSC derived cortical neurons",
  "cellLineBackground": "KOLF2-C1",
  "statisticalTestTail": "upper tail",
  "resourceScore": 0.0063227,
  "log2FoldChangeValue": -0.055668,
  "datasourceId": "ot_crispr",
  "datatypeId": "ot_partner"
}
```

**Validation fails for this:** as expected due to lowercase gene name:

```json
{
  "targetFromSourceId": "cicaful13",
  "diseaseFromSourceMappedId": "EFO_0000249",
  "projectDescription": "iPSC neuron CRISPR",
  "projectId": "OTAR036",
  "studyId": "OTAR036_TAU_uptake_1",
  "studyOverview": "Comparison of functional populations of iPSC neurons based on their ability to take up monomeric/aggregated tau protein",
  "contrast": "TauNEGTransPOS (only transferrin taken up) vs TauPOSTransPOS  (both proteins taken up)",
  "crisprScreenLibrary": "Kosuke v1.1 (Behan et al., 2018)",
  "cellType": "iPSC derived cortical neurons",
  "cellLineBackground": "KOLF2-C1",
  "statisticalTestTail": "upper tail",
  "resourceScore": 0.0063227,
  "log2FoldChangeValue": -0.055668,
  "datasourceId": "ot_crispr",
  "datatypeId": "ot_partner"
}
```