### PR TITLE
Bugfix in schema definition for EPMC's diseaseFromSourceMappedId

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -248,7 +248,7 @@
           "$ref": "#/definitions/datatypeId"
         },
         "diseaseFromSourceMappedId": {
-          "$ref": "#/definitions/diseaseFromSourceId"
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
         },
         "literature": {
           "$ref": "#/definitions/literature"


### PR DESCRIPTION
The `diseaseFromSourceMappedId` field in EPMC was being checked against the `diseaseFromSourceId` definition. Therefore the value of this field is not checked against any pattern.