### PR TITLE
Added "gene_burden" data source to the schema

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -569,6 +569,98 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "gene_burden"
+        },
+        "ancestry": {
+          "$ref": "#/definitions/ancestry"
+        },
+        "ancestryId": {
+          "$ref": "#/definitions/ancestryId"
+        },
+        "beta": {
+          "$ref": "#/definitions/beta"
+        },
+        "betaConfidenceIntervalLower": {
+          "$ref": "#/definitions/betaConfidenceIntervalLower"
+        },
+        "betaConfidenceIntervalUpper": {
+          "$ref": "#/definitions/betaConfidenceIntervalUpper"
+        },
+        "cohortId": {
+          "$ref": "#/definitions/cohortId"
+        },
+        "datatypeId": {
+          "$ref": "#/definitions/datatypeId"
+        },
+        "diseaseFromSource": {
+          "$ref": "#/definitions/diseaseFromSource"
+        },
+        "diseaseFromSourceMappedId": {
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "literature": {
+          "$ref": "#/definitions/literature"
+        },
+        "oddsRatio": {
+          "$ref": "#/definitions/oddsRatio"
+        },
+        "oddsRatioConfidenceIntervalLower": {
+          "$ref": "#/definitions/oddsRatioConfidenceIntervalLower"
+        },
+        "oddsRatioConfidenceIntervalUpper": {
+          "$ref": "#/definitions/oddsRatioConfidenceIntervalUpper"
+        },
+        "projectId": {
+          "$ref": "#/definitions/projectId"
+        },
+        "pValueMantissa": {
+          "$ref": "#/definitions/pValueMantissa"
+        },
+        "pValueExponent": {
+          "$ref": "#/definitions/pValueExponent"
+        },
+        "resourceScore": {
+          "$ref": "#/definitions/resourceScore"
+        },
+        "statisticalMethod": {
+          "$ref": "#/definitions/statisticalMethod"
+        },
+        "statisticalMethodOverview": {
+          "$ref": "#/definitions/statisticalMethodOverview"
+        },
+        "studyId": {
+          "$ref": "#/definitions/studyId"
+        },
+        "studyCases": {
+          "$ref": "#/definitions/studyCases"
+        },
+        "studySampleSize": {
+          "$ref": "#/definitions/studySampleSize"
+        },
+        "targetFromSourceId": {
+          "$ref": "#/definitions/targetFromSourceId"
+        },
+        "urls": {
+          "$ref": "#/definitions/urls"
+        }
+      },
+      "required": [
+        "cohortId",
+        "datasourceId",
+        "diseaseFromSource",
+        "projectId",
+        "resourceScore",
+        "statisticalMethod",
+        "statisticalMethodOverview",
+        "studyCases",
+        "studySampleSize",
+        "targetFromSourceId"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "genomics_england"
         },
         "allelicRequirements": {
@@ -1219,7 +1311,21 @@
     }
   ],
   "definitions": {
-    "alleleOrigins" : {
+    "ancestry": {
+      "type": "string",
+      "description": "Genetic origin of a population.",
+      "examples": [
+        "EUR",
+        "EAS"
+      ]
+    },
+    "ancestryId": {
+      "type": "string",
+      "description": "Identifier of the ancestry in the HANCESTRO ontology",
+      "examples": ["HANCESTRO_006"],
+      "pattern": "HANCESTRO_\\d+"
+    },
+    "alleleOrigins": {
       "type": "array",
       "description": "Origin of the variant allele",
       "items": {
@@ -1406,7 +1512,8 @@
       "type": "string",
       "description": "Identifier of the studied cohort",
       "examples": [
-        "CBIOP_WXS_PRAD_SU2C_2019"
+        "CBIOP_WXS_PRAD_SU2C_2019",
+        "UK Biobank"
       ]
     },
     "cohortShortName": {
@@ -1801,6 +1908,18 @@
       },
       "uniqueItems": true
     },
+    "statisticalMethod": {
+      "type": "string",
+      "description": "The statistical method used to calculate the association.",
+      "examples": [
+        "ADD-WGR-FIRTH_M3.0001",
+        "ptv5pcnt"
+      ]
+    },
+    "statisticalMethodOverview": {
+      "type": "string",
+      "description": "Overview of the statistical method used to calculate the association."
+    },
     "studyCases": {
       "type": "integer",
       "description": "Number of cases in case-control study",
@@ -1808,7 +1927,10 @@
     },
     "studyId": {
       "type": "string",
-      "description": "Identifier of the study"
+      "description": "Identifier of the study",
+      "examples": [
+        "GCST90083260"
+      ]
     },
     "studyOverview": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -581,10 +581,10 @@
           "$ref": "#/definitions/beta"
         },
         "betaConfidenceIntervalLower": {
-          "$ref": "#/definitions/betaConfidenceIntervalLower"
+          "$ref": "#/definitions/confidenceIntervalLower"
         },
         "betaConfidenceIntervalUpper": {
-          "$ref": "#/definitions/betaConfidenceIntervalUpper"
+          "$ref": "#/definitions/confidenceIntervalUpper"
         },
         "cohortId": {
           "$ref": "#/definitions/cohortId"

--- a/opentargets.json
+++ b/opentargets.json
@@ -605,7 +605,7 @@
           "$ref": "#/definitions/oddsRatio"
         },
         "oddsRatioConfidenceIntervalLower": {
-          "$ref": "#/definitions/oddsRatioConfidenceIntervalLower"
+          "$ref": "#/definitions/confidenceIntervalLower"
         },
         "oddsRatioConfidenceIntervalUpper": {
           "$ref": "#/definitions/oddsRatioConfidenceIntervalUpper"

--- a/opentargets.json
+++ b/opentargets.json
@@ -608,7 +608,7 @@
           "$ref": "#/definitions/confidenceIntervalLower"
         },
         "oddsRatioConfidenceIntervalUpper": {
-          "$ref": "#/definitions/oddsRatioConfidenceIntervalUpper"
+          "$ref": "#/definitions/confidenceIntervalUpper"
         },
         "projectId": {
           "$ref": "#/definitions/projectId"


### PR DESCRIPTION
Data model to integrate associations resulting from collapsing analyses as a new data source.
This version currently applies the definition of the proposal v3:

```json
{
	"datasourceId": "gene_burden",
	"datatypeId": "genetic_association",
	"targetFromSourceId": "ACAP3",
	"diseaseFromSource": "6mm weak meridian left (5097)",
	"diseaseFromSourceMappedId": "EFO_0004731",
	"pValueMantissa": 9.25,
	"pValueExponent": -12,
	"beta": -0.148,
	"betaConfidenceIntervalLower": -0.191,
	"betaConfidenceIntervalUpper": -0.106,
	"oddsRatio": null,
	"oddsRatioConfidenceIntervalLower": null,
	"oddsRatioConfidenceIntervalUpper": null,
	"resourceScore": 9.250000e-12,
	"ancestry": "EUR",
	"ancestryId": "HANCESTRO_0009",
	"literature": ["34662886"],
	"projectId": "REGENERON",
	"cohortId": "UK Biobank",
	"studyId": "GCST90083260",
	"studySampleSize": 89735,
	"studyCases": 89735,
	"statisticalMethod": "ADD-WGR-FIRTH_M3.0001",
	"statisticalMethodOverview": "Burden test carried out with pLOFs and deleterious missense with a MAF smaller than 0.001%",
	"urls": null
}
```

Closes [#1941](https://github.com/opentargets/issues/issues/1941).