### PR TITLE
New `variantHgvsId`, `phenodigm` renaming and other improvements

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -666,10 +666,14 @@
         }
       },
       "required": [
+        "ancestry",
+        "ancestryId",
         "cohortId",
         "datasourceId",
         "diseaseFromSource",
+        "literature",
         "projectId",
+        "pValueMantissa",
         "resourceScore",
         "statisticalMethod",
         "statisticalMethodOverview",

--- a/opentargets.json
+++ b/opentargets.json
@@ -1029,7 +1029,7 @@
     {
       "properties": {
         "datasourceId": {
-          "const": "phenodigm"
+          "const": "impc"
         },
         "biologicalModelAllelicComposition": {
           "$ref": "#/definitions/biologicalModelAllelicComposition"

--- a/opentargets.json
+++ b/opentargets.json
@@ -391,6 +391,9 @@
         "variantFunctionalConsequenceId": {
           "$ref": "#/definitions/variantFunctionalConsequenceId"
         },
+        "variantHgvsId": {
+          "$ref": "#/definitions/variantHgvsId"
+        },
         "variantId": {
           "$ref": "#/definitions/variantId"
         },
@@ -453,6 +456,9 @@
         },
         "variantFunctionalConsequenceId": {
           "$ref": "#/definitions/variantFunctionalConsequenceId"
+        },
+        "variantHgvsId": {
+          "$ref": "#/definitions/variantHgvsId"
         },
         "variantId": {
           "$ref": "#/definitions/variantId"
@@ -2262,6 +2268,15 @@
       "pattern": "SO_\\d+",
       "examples": [
         "SO_0001628"
+      ]
+    },
+    "variantHgvsId": {
+      "type": "string",
+      "description": "Identifier in HGVS notation of the disease-causing variant.",
+      "pattern": "^[^?()]*$",
+      "examples": [
+        "NC_000011.10:g.17605796C>T",
+        "LRG_214t1:c.889-1633_7395-667del"
       ]
     },
     "variantId": {


### PR DESCRIPTION
This PR contains:
- New field to store the HGVS representation of a variant ([#2549](https://github.com/opentargets/issues/issues/2549)). `variantHgvsId` will be an optional field for `eva` and `eva_somatic` with a pattern to enforce the absence of uncertain variants (presence of `?` in the string).
- Renaming of the `phenodigm` evidence data source to `impc`. This is a more accurate name since IMPC is the actual service that maintains the data, Phenodigm is rather the algorithm that establishes the link between phenotypes in mice and humans.
- Improved definition of the required fields for `gene_burden`. 