### PR TITLE
Minor fixes

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -2277,7 +2277,6 @@
     "variantHgvsId": {
       "type": "string",
       "description": "Identifier in HGVS notation of the disease-causing variant.",
-      "pattern": "^[^?()]*$",
       "examples": [
         "NC_000011.10:g.17605796C>T",
         "LRG_214t1:c.889-1633_7395-667del"

--- a/opentargets.json
+++ b/opentargets.json
@@ -659,9 +659,6 @@
         },
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
-        },
-        "urls": {
-          "$ref": "#/definitions/urls"
         }
       },
       "required": [

--- a/opentargets.json
+++ b/opentargets.json
@@ -477,7 +477,6 @@
         "studyId",
         "targetFromSourceId",
         "variantFunctionalConsequenceId",
-        "variantId"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
This PR contains:

- Removal of the `variantHgvsId` pattern that prevented any ID to include a question mark. This is because repeat expansion variants will likely violate such constraint, see:
```
{'alleleOrigins': ['germline'], 'datasourceId': 'eva', 'datatypeId': 'genetic_association', 'clinicalSignificances': ['pathogenic'], 'confidence': 'no assertion criteria provided', 'literature': ['8595416'], 'studyId': 'RCV000005352', 'targetFromSourceId': 'ENSG00000267395', 'variantFunctionalConsequenceId': 'SO_0002165', 'variantId': '19_45770204_C_CCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAG', 'cohortPhenotypes': ['Dystrophia myotonica type 1', 'Myotonic dystrophy type 1', 'Steinert disease', 'Steinert myotonic dystrophy', 'Steinert myotonic dystrophy syndrome', "Steinert's disease"], 'diseaseFromSource': 'Steinert myotonic dystrophy syndrome', 'diseaseFromSourceId': 'C3250443', 'diseaseFromSourceMappedId': 'Orphanet_273', 'variantHgvsId': 'NC_000019.10:g.45770205CAG[(51_?)]'}
```
- Removal of `variantId` as a required field for `eva_somatic`. We will be having some evidence without `chrom_pos_ref_alt` coordinates in this release, see:
```
{'alleleOrigins': ['somatic'], 'datasourceId': 'eva_somatic', 'datatypeId': 'somatic_mutation', 'clinicalSignificances': ['uncertain significance'], 'confidence': 'no assertion criteria provided', 'studyId': 'RCV000207248', 'targetFromSourceId': 'ENSG00000165643', 'variantFunctionalConsequenceId': 'SO_0001893', 'cohortPhenotypes': ['Breast cancer, invasive ductal', 'Ductal breast carcinoma'], 'diseaseFromSource': 'Ductal breast carcinoma', 'diseaseFromSourceId': 'C1527349', 'diseaseFromSourceMappedId': 'EFO_0006318', 'variantHgvsId': 'NC_000009.12:g.135665886_135775364del'}
```
- Removal of `urls` as a field for `gene_burden`. The intention was to accommodate in this field a linkout to the AZ PheWAS Portal that were related to the evidence. At the moment this is not reliable, as we are not clear about the base url we should be using. This field will be dropped for now and clarified later with the AZ contact person.
