### PR TITLE
fixing travis issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install git+git://github.com/Julian/jsonschema.git@v3.0.2#egg=jsonschema
+  - pip install git+https://github.com/Julian/jsonschema.git@v3.0.2#egg=jsonschema
   - wget -O draft7.json http://json-schema.org/draft-07/schema
   - wget -O draft4.json http://json-schema.org/draft-04/schema
 script:
+  - jsonschema -i opentargets_target_safety.json draft7.json 
+  - jsonschema -i opentargets_tep.json draft7.json
   - jsonschema -i opentargets.json draft7.json
   - jsonschema -i OT_network_schema.json draft4.json

--- a/opentargets.json
+++ b/opentargets.json
@@ -476,7 +476,7 @@
         "diseaseFromSource",
         "studyId",
         "targetFromSourceId",
-        "variantFunctionalConsequenceId",
+        "variantFunctionalConsequenceId"
       ],
       "additionalProperties": false
     },

--- a/opentargets_target_safety.json
+++ b/opentargets_target_safety.json
@@ -6,22 +6,31 @@
     "properties": {
       "id": {
         "description": "Target ID (accepted sources include Ensembl gene ID, Uniprot ID).",
-        "examples": "ENSG00000133019",
+        "examples": 
+        [
+          "ENSG00000133019"
+        ],
         "type": "string"
       },
       "targetFromSourceId": {
         "description": "Gene symbol in resource of origin.",
-        "examples": "ESR1",
+        "examples": [
+          "ESR1"
+        ],
         "type": "string"
       },
       "event": {
         "description": "Identifier of the biological process in the EFO ontology.",
-        "examples": "arrhythmia",
+        "examples": [
+          "arrhythmia"
+        ],
         "type": "string"
       },
       "eventId": {
         "description": "Identifier of the safety event in the EFO ontology.",
-        "examples": "EFO_0004269",
+        "examples": [
+          "EFO_0004269"
+        ],
         "type": "string"
       },
       "biosample": {
@@ -66,22 +75,30 @@
         "properties": {
           "cellFormat": {
             "description": "Cellular or subcellular format of the assay.",
-            "examples": "cell line",
+            "examples": [
+              "cell line"
+            ],
             "type": "string"
           },
           "cellLabel": {
             "description": "Name of the cell line or primary cell in source.",
-            "examples": "T47D",
+            "examples": [
+              "T47D"
+            ],
             "type": "string"
           },
           "tissueId": {
             "description": "Identifier of the tissue in the UBERON ontology.",
-            "examples": "UBERON_0004535",
+            "examples": [
+              "UBERON_0004535"
+            ],
             "type": "string"
           },
           "tissueLabel": {
             "description": "Anatomical entity at an organ-level of the protein or cell used in the assay.",
-            "examples": "cardiovascular system",
+            "examples": [
+              "cardiovascular system"
+            ],
             "type": "string"
           }
         },
@@ -133,12 +150,16 @@
           },
           "name": {
             "description": "Name of the study.",
-            "examples": "ACEA_ER_80hr",
+            "examples": [
+              "ACEA_ER_80hr"
+            ],
             "type": "string"
           },
           "type": {
             "description": "Conceptual biological and/or chemical features of the study.",
-            "examples": "cell-based",
+            "examples": [
+              "cell-based"
+            ],
             "type": "string"
           }
         },


### PR DESCRIPTION
The travis deploy test was constantly failing. It was due to the more strict github security policies. 
- [ ] The `git://` protocol was no longer supported to fetch repository. Instead it needed to switch to `https://`. 
- [ ] Also the new TEP and target safety tests were added to the test.