### PR TITLE
Add `studyCasesWithQualifyingVariants` to `gene_burden` and minor fixes

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -2084,7 +2084,7 @@
         "ENSG00000012048",
         "P38398"
       ],
-      "pattern": "^[a-zA-Z0-9-]+$"
+      "pattern": "^[a-zA-Z0-9-.]+$"
     },
     "targetFromSource": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -2084,7 +2084,7 @@
         "ENSG00000012048",
         "P38398"
       ],
-      "pattern": "^[A-Z0-9-]+$"
+      "pattern": "^[a-zA-Z0-9-]+$"
     },
     "targetFromSource": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -654,8 +654,8 @@
         "studyCases": {
           "$ref": "#/definitions/studyCases"
         },
-        "studyCasesWithQV": {
-          "$ref": "#/definitions/studyCasesWithQV"
+        "studyCasesWithQualifyingVariants": {
+          "$ref": "#/definitions/studyCasesWithQualifyingVariants"
         },
         "studySampleSize": {
           "$ref": "#/definitions/studySampleSize"
@@ -677,7 +677,7 @@
         "statisticalMethod",
         "statisticalMethodOverview",
         "studyCases",
-        "studyCasesWithQV",
+        "studyCasesWithQualifyingVariants",
         "studySampleSize",
         "targetFromSourceId"
       ],
@@ -2018,7 +2018,7 @@
       "description": "Number of cases in case-control study.",
       "exclusiveMinimum": 0
     },
-    "studyCasesWithQV": {
+    "studyCasesWithQualifyingVariants": {
       "type": "integer",
       "description": "Number of cases in case-control study that carry at least one allele of the qualifying variant."
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -2084,7 +2084,7 @@
         "ENSG00000012048",
         "P38398"
       ],
-      "pattern": "^[A-Z0-9]+$"
+      "pattern": "^[A-Z0-9-]+$"
     },
     "targetFromSource": {
       "type": "string",

--- a/opentargets.json
+++ b/opentargets.json
@@ -654,6 +654,9 @@
         "studyCases": {
           "$ref": "#/definitions/studyCases"
         },
+        "studyCasesWithQV": {
+          "$ref": "#/definitions/studyCasesWithQV"
+        },
         "studySampleSize": {
           "$ref": "#/definitions/studySampleSize"
         },
@@ -674,6 +677,7 @@
         "statisticalMethod",
         "statisticalMethodOverview",
         "studyCases",
+        "studyCasesWithQV",
         "studySampleSize",
         "targetFromSourceId"
       ],
@@ -2011,8 +2015,12 @@
     },
     "studyCases": {
       "type": "integer",
-      "description": "Number of cases in case-control study",
+      "description": "Number of cases in case-control study.",
       "exclusiveMinimum": 0
+    },
+    "studyCasesWithQV": {
+      "type": "integer",
+      "description": "Number of cases in case-control study that carry at least one allele of the qualifying variant."
     },
     "studyId": {
       "type": "string",


### PR DESCRIPTION
This PR contains the inclusion of a field in the schema to report the number of cases that carry a qualifying variant in the study. 

During yesterday's SU we had decided that this piece of information was not relevant because it would require to add more fields to interpret it (same metric given for the controls, number of qualifying variants).

However, I had a discussion with @d0choa later and his point was that having the frequency of the variant (nº of cases that are carriers / nº of total cases) is informative of how stringent the model is, and it enables the user to make comparisons between models.

I am not entirely convinced about the name, though. Some options are:
- studyCasesWithQV
- studyCasesWithQualifyingVariant
- studyCasesQualifyingVariant
- studyCasesWithMutation
- studyCasesVariantCarriers
- studyCasesMutationCarriers

This field is very similar to `mutatedSamples.numberSamplesWithMutationType`. In a next iteration we could adapt `mutatedSample` to work with cases/controls studies. 