### PR TITLE
Add schema for Chemical Probes V1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - wget -O draft7.json http://json-schema.org/draft-07/schema
   - wget -O draft4.json http://json-schema.org/draft-04/schema
 script:
+  - jsonschema -i opentargets_chemical_probe.json draft7.json
   - jsonschema -i opentargets_target_safety.json draft7.json 
   - jsonschema -i opentargets_tep.json draft7.json
   - jsonschema -i opentargets.json draft7.json

--- a/opentargets_chemical_probe.json
+++ b/opentargets_chemical_probe.json
@@ -1,0 +1,115 @@
+{
+    "title": "OpenTargets-chemical-probes",
+    "description": "OpenTargets Target Safety Liabilities model.",
+    "type": "object",
+    "properties": {
+      "targetFromSourceId": {
+        "description": "Gene symbol in resource of origin.",
+        "examples": "ESR1",
+        "type": "string"
+      },
+      "id": {
+        "description": "Probe ID as reported in Probes&Drugs.",
+        "examples": "IOX1",
+        "type": "string"
+      },
+      "control": {
+        "description": "Inactive analogue of the probe.",
+        "examples": "PF-04875474",
+        "type": "string"
+      },
+      "drugId": {
+        "description": "Drug molecule ID.",
+        "examples": "CHEMBL1651534",
+        "type": "string"
+      },
+      "inchiKey": {
+        "description": "ID that identifies the probe.",
+        "examples": "JGRPKOGHYBAVMW-UHFFFAOYSA-N",
+        "type": "string"
+      },
+      "urls": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/url"
+        }
+      },
+      "probesDrugsScore": {
+        "description": "P&D probe-likeness score.",
+        "exclusiveMinimum": 0,
+        "maximum": 100,
+        "type": "integer"
+      },
+      "probeMinerScore": {
+        "description": "Probe Miner probe-likeness score.",
+        "exclusiveMinimum": 0,
+        "maximum": 100,
+        "type": "integer"
+      },
+      "scoreInCells": {
+        "description": "ChemicalProbes.org score for probe-likeness to be used in model cells.",
+        "exclusiveMinimum": 0,
+        "maximum": 100,
+        "type": "integer"
+      },
+      "scoreInOrganisms": {
+        "description": "ChemicalProbes.org score for probe-likeness to be used in model organisms.",
+        "exclusiveMinimum": 0,
+        "maximum": 100,
+        "type": "integer"
+      },
+      "mechanismOfAction": {
+        "description": "Mechanism of action of the probe.",
+        "examples": [
+          "blocker"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "isHighQuality": {
+        "description": "True if selected as high quality by P&D.",
+        "type": "boolean"
+      },
+      "origin": {
+        "description": "Origin of the probe.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "experimental",
+            "calculated"
+        ],
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "required": [
+      "targetFromSourceId",
+      "id",
+      "inchiKey",
+      "urls",
+      "isHighQuality",
+      "origin"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+      "url": {
+        "type": "object",
+        "properties": {
+          "niceName": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "niceName"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }

--- a/opentargets_chemical_probe.json
+++ b/opentargets_chemical_probe.json
@@ -1,6 +1,6 @@
 {
     "title": "OpenTargets-chemical-probes",
-    "description": "OpenTargets Target Safety Liabilities model.",
+    "description": "OpenTargets Chemical Probes model.",
     "type": "object",
     "properties": {
       "targetFromSourceId": {

--- a/opentargets_chemical_probe.json
+++ b/opentargets_chemical_probe.json
@@ -5,27 +5,27 @@
     "properties": {
       "targetFromSourceId": {
         "description": "Gene symbol in resource of origin.",
-        "examples": "ESR1",
+        "examples": ["ESR1"],
         "type": "string"
       },
       "id": {
         "description": "Probe ID as reported in Probes&Drugs.",
-        "examples": "IOX1",
+        "examples": ["IOX1"],
         "type": "string"
       },
       "control": {
         "description": "Inactive analogue of the probe.",
-        "examples": "PF-04875474",
+        "examples": ["PF-04875474"],
         "type": "string"
       },
       "drugId": {
         "description": "Drug molecule ID.",
-        "examples": "CHEMBL1651534",
+        "examples": ["CHEMBL1651534"],
         "type": "string"
       },
       "inchiKey": {
         "description": "ID that identifies the probe.",
-        "examples": "JGRPKOGHYBAVMW-UHFFFAOYSA-N",
+        "examples": ["JGRPKOGHYBAVMW-UHFFFAOYSA-N"],
         "type": "string"
       },
       "urls": {

--- a/pydantic_models/chemical_probes.py
+++ b/pydantic_models/chemical_probes.py
@@ -1,0 +1,54 @@
+import json
+from typing import List, Optional
+
+from pydantic import BaseModel, Extra, Field
+
+
+class Url(BaseModel):
+    niceName: str
+    url: Optional[str]
+
+    class Config:
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+class ChemicalProbes(BaseModel):
+    """
+    OpenTargets Chemical Probes model.
+    """
+
+    targetFromSourceId: str = Field(description='Gene symbol in resource of origin.', examples='ESR1')
+    id: str = Field(description='Probe ID as reported in Probes&Drugs.', examples='IOX1')
+    control: Optional[str] = Field(description='Inactive analogue of the probe.', examples='PF-04875474')
+    drugId: Optional[str] = Field(description='Drug molecule ID.', examples='CHEMBL1651534')
+    inchiKey: str = Field(description='ID that identifies the probe.', examples='JGRPKOGHYBAVMW-UHFFFAOYSA-N')
+    urls: List[Url]
+    probesDrugsScore: Optional[int] = Field(description='P&D probe-likeness score.', gt=0, le=100)
+    probeMinerScore: Optional[int] = Field(description='Probe Miner probe-likeness score.', gt=0, le=100)
+    scoreInCells: Optional[int] = Field(description='ChemicalProbes.org score for probe-likeness to be used in model cells.', gt=0, le=100)
+    scoreInOrganisms: Optional[int] = Field(description='ChemicalProbes.org score for probe-likeness to be used in model organisms.', gt=0, le=100)
+    mechanismOfAction: Optional[List[str]] = Field(description='Mechanism of action of the probe.', examples=['blocker'])
+    isHighQuality: bool = Field(description='True if selected as high quality by P&D.')
+    origin: List[str] = Field(description='Origin of the probe.')
+
+    class Config:
+        title = 'OpenTargets-chemical-probes'
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+### Example validation
+
+ex = '{"targetFromSourceId":"O00519","id":"PF-04457845","drugId":"CHEMBL1651534","inchiKey":"BATCTBJIJJEPHM-UHFFFAOYSA-N","urls":[{"niceName":"Chemical Probes.org (legacy)","url":"https://new.chemicalprobes.org/?q=PF-04457845"},{"niceName":"Open Science Probes","url":"http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04457845"}],"control":"PF-04875474","probesDrugsScore":70.0,"probeMinerScore":41.0,"scoreInCells":50.0,"scoreInOrganisms":100.0,"mechanismOfAction":["inhibitor"],"isHighQuality":true,"origin":["experimental"]}'
+
+def validator(item):
+    try:
+        ChemicalProbes(**json.loads(item))
+
+    except pydantic.ValidationError as exc:
+        print(f"ERROR: Invalid schema: {exc}")
+        return False
+
+    return True
+    
+print(validator(ex))
+print(ChemicalProbes.schema_json(indent=2))

--- a/pydantic_models/target_safety_liabilities.py
+++ b/pydantic_models/target_safety_liabilities.py
@@ -1,0 +1,84 @@
+import json
+from typing import List, Optional
+
+from pydantic import BaseModel, Extra, Field
+from pydantic.schema import schema
+
+
+class Biosample(BaseModel):
+    """
+    Anatomical structures referenced in resource.
+    """
+
+    cellFormat: Optional[str] = Field(description='Cellular or subcellular format of the assay.', examples='cell line')
+    cellLabel: Optional[str] = Field(description='Name of the cell line or primary cell in source.', examples='T47D')
+    tissueId: Optional[str] = Field(description='Identifier of the tissue in the UBERON ontology.', examples='UBERON_0004535')
+    tissueLabel: Optional[str] = Field(description='Anatomical entity at an organ-level of the protein or cell used in the assay.', examples='cardiovascular system')
+
+    class Config:
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+class Effect(BaseModel):
+    """
+    Effect on target modulation.
+    """
+
+    direction: str = Field(description='Direction of the effect.')
+    dosing: str = Field(description='Required dose to achieve the response.')
+    class Config:
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+class Effects(BaseModel):
+    __root__: List[Effect] = Field(unique_items=True)
+
+class Study(BaseModel):
+    """
+    Characteristics of the study.
+    """
+
+    description: Optional[str] = Field(description='Description of the study.')
+    name: Optional[str] = Field(description='Name of the study.', examples='ACEA_ER_80hr')
+    type: Optional[str] = Field(description='Conceptual biological and/or chemical features of the study.', examples='cell-based')        
+    class Config:
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+class TargetSafety(BaseModel):
+    """
+    OpenTargets Target Safety Liabilities model.
+    """
+
+    id: Optional[str] = Field(description='Target ID (accepted sources include Ensembl gene ID, Uniprot ID).', examples='ENSG00000133019')
+    targetFromSourceId: Optional[str] = Field(description='Gene symbol in resource of origin.', examples='ESR1')
+    event: str = Field(description='Identifier of the biological process in the EFO ontology.', examples='arrhythmia')
+    eventId: Optional[str] = Field(description='Identifier of the safety event in the EFO ontology.', examples='EFO_0004269')
+    biosample: Optional[Biosample]
+    effects: Optional[Effects]
+    datasource: str = Field(description='Source of safety event.')
+    literature: Optional[str] = Field(description='PubMed reference identifier.', regex='\d+$')
+    study: Optional[Study]
+    url: Optional[str]
+
+    class Config:
+        title = 'OpenTargets-target-safety'
+        extra = Extra.forbid
+        anystr_strip_whitespace = True
+
+### Example validation
+
+ex = '{"id":"ENSG00000082556","event":"interaction with dopaminergic transmission and hallucination","datasource":"Urban et al. (2012)","url":"https://doi.org/10.1002/9781118098141.ch2","biosample":{"tissueLabel":"nervous system","tissueId":"UBERON_0001016"},"effects":[{"direction":"activation","dosing":"general"}]}'
+
+def validator(item):
+    try:
+        TargetSafety(**json.loads(item))
+
+    except pydantic.ValidationError as exc:
+        print(f"ERROR: Invalid schema: {exc}")
+        return False
+
+    return True
+    
+print(validator(ex))
+#print(TargetSafety.schema_json(indent=2))


### PR DESCRIPTION
This new schema validates the output of the Chemical Probes dataset, which is part of the Target annotation. The latest dataset is found at `gs://open-targets-pre-data-releases/22.04/input/target-inputs/chemicalprobes`

This dataset is currently produced with a Jupyter notebook but the plan is to move this logic to a standalone script (see [#1711](https://github.com/opentargets/issues/issues/1711))

**Note:** I've changed some types in the schema that will cause that the strings of the above dataset will fall validation. The fields that were reporting scores are of type **str**, now they have been changed to treat them as **numbers** so that we can enforce them to be within a 0-100 range. The affected fields are: `probesDrugsScore`, `probeMinerScore`, `scoreInCells`, `scoreInOrganisms`.

An example JSON string:
```
{
  "targetFromSourceId": "O00519",
  "id": "PF-04457845",
  "drugId": "CHEMBL1651534",
  "inchiKey": "BATCTBJIJJEPHM-UHFFFAOYSA-N",
  "urls": [
    {
      "niceName": "Chemical Probes.org (legacy)",
      "url": "https://new.chemicalprobes.org/?q=PF-04457845"
    },
    {
      "niceName": "Open Science Probes",
      "url": "http://www.sgc-ffm.uni-frankfurt.de/#!specificprobeoverview/PF-04457845"
    }
  ],
  "control": "PF-04875474",
  "probesDrugsScore": 70,
  "probeMinerScore": 41,
  "scoreInCells": 50,
  "scoreInOrganisms": 100,
  "mechanismOfAction": [
    "inhibitor"
  ],
  "isHighQuality": true,
  "origin": [
    "experimental"
  ]
}
```

The JSON schema has been generated from the model specified with Pydantic with minimal manual changes: specifying the enums (which can also be achieved with Pydantic), and removing the field title which is added by default. Gist that produces the JSON Schema: https://gist.github.com/ireneisdoomed/c80a497d3c53ea3858fcaac076547d3a
