### PR TITLE
Added `likely risk allele` as a new clinical significance

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1560,6 +1560,7 @@
           "conflicting interpretations of pathogenicity",
           "drug response",
           "likely benign",
+          "likely risk allele",
           "likely pathogenic",
           "not provided",
           "other",


### PR DESCRIPTION
ClinVar will report evidence with a new clinical significance. `likely risk allele` is a new level of significance for variants with decreased penetrance for Mendelian conditions, as recommended by [ClinGen](https://clinicalgenome.org/site/assets/files/4531/clingenrisk_terminology_recomendations-final-02_18_20.pdf).

This will affect evidence submitted by EVA.