### PR TITLE
Add `allelicRequirements` to gene_burden

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -600,6 +600,9 @@
         "datasourceId": {
           "const": "gene_burden"
         },
+        "allelicRequirements": {
+          "$ref": "#/definitions/allelicRequirements"
+        },
         "ancestry": {
           "$ref": "#/definitions/ancestry"
         },

--- a/opentargets.json
+++ b/opentargets.json
@@ -677,11 +677,7 @@
         }
       },
       "required": [
-        "ancestry",
-        "ancestryId",
-        "cohortId",
         "datasourceId",
-        "diseaseFromSource",
         "literature",
         "projectId",
         "pValueMantissa",
@@ -689,7 +685,6 @@
         "statisticalMethod",
         "statisticalMethodOverview",
         "studyCases",
-        "studyCasesWithQualifyingVariants",
         "studySampleSize",
         "targetFromSourceId"
       ],


### PR DESCRIPTION
This PR includes changes to the `gene_burden` source after the work described in [#2604](https://github.com/opentargets/issues/issues/2604).