### PR TITLE
Additional changes to accommodate gene_burden evidence

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1948,8 +1948,7 @@
     },
     "pValueExponent": {
       "type": "integer",
-      "description": "p-value (e.g. GWAS association) exponent",
-      "maximum": -8
+      "description": "p-value (e.g. GWAS association) exponent"
     },
     "pValueMantissa": {
       "type": "number",

--- a/opentargets.json
+++ b/opentargets.json
@@ -679,7 +679,6 @@
       "required": [
         "datasourceId",
         "literature",
-        "projectId",
         "pValueMantissa",
         "resourceScore",
         "statisticalMethod",


### PR DESCRIPTION
2 more changes are necessary for the `gene_burden` data source:
- `projectId` is no longer always present. We don't have such field for the associations with CKD.
- I had to remove the minimum of `-8` for the exponent of the p value. We have p values higher than that. For example, many genes which the Autism Consortium reports to be significantly associated with autism have higher p values. Their significance threshold is measured on those tests with a FDR ≤ 0.1.