### PR TITLE
Adding variant functional consequence to schema.

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -815,6 +815,9 @@
         },
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
+        },
+        "variantFunctionalConsequenceId": {
+          "$ref": "#/definitions/variantFunctionalConsequenceId"
         }
       },
       "required": [


### PR DESCRIPTION
To enrich evidence from Orphanet with variant functional consequence id, we have to enable this field in the json schema.