### PR TITLE
Burden: Remove `literature` from required field

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -627,6 +627,9 @@
         "diseaseFromSource": {
           "$ref": "#/definitions/diseaseFromSource"
         },
+        "diseaseFromSourceId": {
+          "$ref": "#/definitions/diseaseFromSourceId"
+        },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         },

--- a/opentargets.json
+++ b/opentargets.json
@@ -678,7 +678,6 @@
       },
       "required": [
         "datasourceId",
-        "literature",
         "pValueMantissa",
         "resourceScore",
         "statisticalMethod",


### PR DESCRIPTION
The publication supporting Genebass associations hasn't been peer reviewed yet, therefore we don't have a suitable ID for it.
As discussed, we want to include an additional field in the schema to accommodate PPR IDs - especially to get EPMC evidence, however we don't want to do this right now as it would imply changes in the API and so on. So for the time being, Genebass evidence will only be referenced with a linkout to their app and not with a publication.