### PR TITLE
Remove `inchiKey` from the probes schema

### DIFF
--- a/opentargets_chemical_probe.json
+++ b/opentargets_chemical_probe.json
@@ -23,11 +23,6 @@
         "examples": ["CHEMBL1651534"],
         "type": "string"
       },
-      "inchiKey": {
-        "description": "ID that identifies the probe.",
-        "examples": ["JGRPKOGHYBAVMW-UHFFFAOYSA-N"],
-        "type": "string"
-      },
       "urls": {
         "type": "array",
         "items": {
@@ -89,7 +84,6 @@
     "required": [
       "targetFromSourceId",
       "id",
-      "inchiKey",
       "urls",
       "isHighQuality",
       "origin"


### PR DESCRIPTION
After discussion, we've decided to drop the field referring to the inchikey from the definition of a chemical probe. This is primarily used to being able to map from a probe to a ChEMBL ID.

The reason for the drop is that it was introducing some bugs when for the same probe we had a row with an inchikey and another one without. This is the case for Talazoparib, a probe of PARP1. The data was not being aggregated because of this discrepancy, leading to [duplicated rows in the FE](https://platform.opentargets.org/target/ENSG00000143799).

```
        {
          "id": "TALAZOPARIB",
          "control": null,
          "drugId": null,
          "isHighQuality": false,
          "mechanismOfAction": [
            "inhibitor"
          ],
          "origin": [
            "calculated",
            "experimental"
          ],
          "probeMinerScore": null,
          "probesDrugScore": null,
          "scoreInCells": null,
          "scoreInOrganisms": null,
          "targetFromSourceId": "P09874",
          "urls": [
            {
              "niceName": "Chemical Probes.org (legacy)",
              "url": "https://new.chemicalprobes.org/?q=TALAZOPARIB"
            }
          ]
        },
        {
          "id": "TALAZOPARIB",
          "control": null,
          "drugId": "CHEMBL3137320",
          "isHighQuality": true,
          "mechanismOfAction": [
            "inhibitor"
          ],
          "origin": [
            "experimental"
          ],
          "probeMinerScore": "53.0",
          "probesDrugScore": null,
          "scoreInCells": "83.25",
          "scoreInOrganisms": "91.75",
          "targetFromSourceId": "P09874",
          "urls": [
            {
              "niceName": "Probes & Drugs Portal",
              "url": "https://www.probes-drugs.org"
            }
          ]
        },
```