### PR TITLE
Add `publicationYear` to the EPMC evidence

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -334,6 +334,9 @@
         "literature": {
           "$ref": "#/definitions/literature"
         },
+        "publicationYear": {
+          "$ref": "#/definitions/publicationYear"
+        },
         "resourceScore": {
           "$ref": "#/definitions/resourceScore"
         },
@@ -350,6 +353,7 @@
       "required": [
         "datasourceId",
         "diseaseFromSourceMappedId",
+        "publicationYear",
         "resourceScore",
         "targetFromSourceId",
         "textMiningSentences"


### PR DESCRIPTION
This field is always present in EPMC evidence.