### PR TITLE
feat: New evidence field to report the sex of the analysed people

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -654,6 +654,9 @@
         "resourceScore": {
           "$ref": "#/definitions/resourceScore"
         },
+        "sex": {
+          "$ref": "#/definitions/sex"
+        },
         "statisticalMethod": {
           "$ref": "#/definitions/statisticalMethod"
         },
@@ -2003,6 +2006,15 @@
       "description": "Score provided by datasource indicating strength of target-disease association",
       "minimum": 0.0
     },
+    "sex": {
+      "type": "string",
+      "description": "Sex of the population included in the analysis",
+      "enum": [
+        "men",
+        "women"
+      ]
+    }
+    ,
     "significantDriverMethods": {
       "type": "array",
       "description": "Methods to detect cancer driver genes producing significant results",

--- a/opentargets.json
+++ b/opentargets.json
@@ -2007,12 +2007,15 @@
       "minimum": 0.0
     },
     "sex": {
-      "type": "string",
+      "type": "array",
       "description": "Sex of the population included in the analysis",
-      "enum": [
-        "men",
-        "women"
-      ]
+      "items": {
+        "type": "string",
+        "enum": [
+          "men",
+          "women"
+        ]
+      }
     }
     ,
     "significantDriverMethods": {


### PR DESCRIPTION
Sex is added to the gene_burden schema to capture the sex-specific associations observed in PMID:35999217 (more context in the [ticket](https://github.com/opentargets/issues/issues/2701))

This field is an array where all the possible values are "women" and "men".