### PR TITLE
feat: allow PPR IDs in `literature`

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1845,7 +1845,7 @@
       "description": "PubMed reference identifiers",
       "items": {
         "type": "string",
-        "pattern": "\\d+$"
+        "pattern": "(PPR)?\\d+"
       },
       "uniqueItems": true
     },

--- a/opentargets.json
+++ b/opentargets.json
@@ -1842,7 +1842,7 @@
     },
     "literature": {
       "type": "array",
-      "description": "PubMed reference identifiers",
+      "description": "PubMed or preprint reference identifiers",
       "items": {
         "type": "string",
         "pattern": "(PPR)?\\d+"


### PR DESCRIPTION
This PR is related to #2805. We want to include preprint references in the literature field.