### PR TITLE
feat: adding variantFunctionalConsequenceFromQtlId to ot_genetics

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1036,6 +1036,9 @@
         "variantFunctionalConsequenceId": {
           "$ref": "#/definitions/variantFunctionalConsequenceId"
         },
+        "variantFunctionalConsequenceFromQtlId": {
+          "$ref": "#/definitions/variantFunctionalConsequenceId"
+        },
         "variantId": {
           "$ref": "#/definitions/variantId"
         },


### PR DESCRIPTION
This is an other column holding SO terms (hence pointing to the same field as the `variantFunctionalConsequenceId`). This field is holding the SO term of the corresponding effect direction of the overlapping QTL.