### PR TITLE
feat: change`clinicalPhase` from integer to number

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1553,10 +1553,10 @@
       "additionalProperties": false
     },
     "clinicalPhase": {
-      "type": "integer",
+      "type": "number",
       "description": "Phase of the clinical trial",
-      "minimum": 0,
-      "maximum": 4
+      "minimum": 0.5,
+      "maximum": 4.0
     },
     "clinicalSignificances": {
       "type": "array",


### PR DESCRIPTION
This is part of the changes described in #2878.

ChEMBL has changed their clinical trial phase definitions. They have basically introduced a new tier, `0.5`, to define molecules that are in early phase I studies. A more through description can be found in their [docs](https://chembl.blogspot.com/2023/03/what-is-max-phase-in-chembl.html).

This leads us to having to change the datatype of this field. We will no longer have phase 0, the minimum being 0.5 and the maximum 4.0.