### PR TITLE
Ds crispr screen schema

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -285,6 +285,9 @@
         },
         "studyId": {
           "$ref": "#/definitions/studyId"
+        },
+        "geneticBackground": {
+          "$ref": "#/definitions/geneticBackground"
         }
       },
       "required": [

--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -242,6 +242,66 @@
     {
       "properties": {
         "datasourceId": {
+          "const": "crispr_screen"
+        },
+        "datatypeId": {
+          "$ref": "#/definitions/datatypeId"
+        },
+        "cellType": {
+          "$ref": "#/definitions/cellType"
+        },
+        "diseaseFromSource": {
+          "$ref": "#/definitions/diseaseFromSource"
+        },
+        "literature": {
+          "$ref": "#/definitions/literature"
+        },
+        "resourceScore": {
+          "$ref": "#/definitions/resourceScore"
+        },
+        "targetFromSourceId": {
+          "$ref": "#/definitions/targetFromSourceId"
+        },
+        "diseaseFromSourceMappedId": {
+          "$ref": "#/definitions/diseaseFromSourceMappedId"
+        },
+        "projectId": {
+          "$ref": "#/definitions/projectId"
+        },
+        "crisprScreenLibrary": {
+          "$ref": "#/definitions/crisprScreenLibrary"
+        },
+        "studyOverview": {
+          "$ref": "#/definitions/studyOverview"
+        },
+        "contrast": {
+          "$ref": "#/definitions/contrast"
+        },
+        "statisticalTestTail": {
+          "$ref": "#/definitions/statisticalTestTail"
+        },
+        "log2FoldChangeValue": {
+          "$ref": "#/definitions/log2FoldChangeValue"
+        },
+        "studyId": {
+          "$ref": "#/definitions/studyId"
+        }
+      },
+      "required": [
+        "datasourceId",
+        "datatypeId",
+        "cellType",
+        "diseaseFromSourceMappedId",
+        "resourceScore",
+        "targetFromSourceId",
+        "contrast",
+        "studyId"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "datasourceId": {
           "const": "encore"
         },
         "biomarkerList": {


### PR DESCRIPTION
Validating an evidence like this:
```json
{
  "studyId": "Glutamatergic Neuron-Survival-CRISPRi",
  "datatypeId": "affected_pathway",
  "datasourceId": "crispr_screen",
  "projectId": "crispr_brain",
  "crisprScreenLibrary": "Genome-wide CRISPRi-v2",
  "studyOverview": "CRISPRi survival screen in human iPSC-derived glutamatergic neurons (standard medium).",
  "cellType": "Glutamatergic Neuron",
  "literature": [
    "34031600"
  ],
  "diseaseFromSource": "essential genes / neurodegenerative disease",
  "diseaseFromSourceMappedId": "EFO_0005772",
  "contrast": "Survival",
  "targetFromSourceId": "SOD2",
  "resourceScore": 0.0029283011705045,
  "statisticalTestTail": "lower tail",
  "log2FoldChangeValue": -24.05642773885583
}
```

Important to note, not new field is introduced into the schema.