### PR TITLE
Change units from FPKM to TPM in the baseline expression schema

### DIFF
--- a/schemas/baseline_expression.json
+++ b/schemas/baseline_expression.json
@@ -24,7 +24,7 @@
           "bodyPartLevel",
           "bodyPartId",
           "bodyPartName",
-          "fpkm"
+          "tpm"
         ],
         "properties": {
           "bodyPartLevel": {
@@ -36,9 +36,9 @@
           "bodyPartName": {
             "$ref": "#/definitions/bodyPartName"
           },
-          "fpkm": {
+          "tpm": {
             "type": "number",
-            "description": "Expression value expressed in FPKM units",
+            "description": "Expression value expressed in TPM units",
             "examples": [
               6.0,
               5.0,


### PR DESCRIPTION
There is no significant difference between TPM and FPKM when it comes to calculating baseline expression. For the initial version, FPKM was chosen mostly by chance.

However:
* GTEx V8 provides by-gene median results in TPM
* Single cell data which Lucy is currently working on is expressed in CPM (counts per million), which is conceptually alisnged
* TPM is easier for people to understand

Hence, the decision to change the schema for TPM.