### PR TITLE
feat: adding releaseDate to eva and eva-somatic schema

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -475,6 +475,9 @@
         },
         "variantRsId": {
           "$ref": "#/definitions/variantRsId"
+        },
+        "releaseDate": {
+          "$ref": "#/definitions/releaseDate"
         }
       },
       "required": [
@@ -541,6 +544,9 @@
         },
         "variantRsId": {
           "$ref": "#/definitions/variantRsId"
+        },
+        "releaseDate": {
+          "$ref": "#/definitions/releaseDate"
         }
       },
       "required": [


### PR DESCRIPTION
EVA is now providing creation date of RCVs from ClinVar. The field is not called as `creationDate` because we already have `releaseDate` in the schema. This might be a source of confusion, as this is not referring to the release date per se. I decided to use the already existing field to keep data model slim. 

We need to provide explanation in the documentation though. 