### PR TITLE
feat: adding targetFromSource to scrisp evidence

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -226,6 +226,9 @@
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
         },
+        "targetFromSource": {
+          "$ref": "#/definitions/targetFromSource"
+        },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         }


### PR DESCRIPTION
Minor update that includes target symbol from the original project score table.