### PR TITLE
feat: add support for `Ontology of Biological Attributes`

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1817,7 +1817,7 @@
     "diseaseFromSourceMappedId": {
       "type": "string",
       "description": "Identifier of the disease in the EFO ontology",
-      "pattern": "(^NCIT_C\\d+$|^Orphanet_\\d+$|^GO_\\d+$|^HP_\\d+$|^EFO_\\d+$|^MONDO_\\d+$|^DOID_\\d+$|^MP_\\d+$|^OTAR_\\d+$|^PATO_\\d+$|^CHEBI_\\d+$|^OBI_\\d+$|^OGMS_\\d+$)",
+      "pattern": "(^NCIT_C\\d+$|^Orphanet_\\d+$|^GO_\\d+$|^HP_\\d+$|^EFO_\\d+$|^MONDO_\\d+$|^DOID_\\d+$|^MP_\\d+$|^OTAR_\\d+$|^PATO_\\d+$|^CHEBI_\\d+$|^OBI_\\d+$|^OBA_\\d+$|^OGMS_\\d+$)",
       "examples": [
         "EFO_0005537"
       ]


### PR DESCRIPTION
... as requested by EVA

>  OBA is a standardised representational framework for observable attributes that are characteristics of biological entities, organisms, or parts of organisms (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9900877/)

Some examples that will be included in ClinVar's new evidence set are related to drug responses (e.g. [this](https://www.ebi.ac.uk/ols4/ontologies/efo/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FOBA_2040133) or [this](https://www.ebi.ac.uk/ols4/ontologies/efo/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FOBA_2040128))