### PR TITLE
feat(pgx): encapsulate drug information in an array of structs

### DIFF
--- a/pydantic_models/pharmacogenomics.py
+++ b/pydantic_models/pharmacogenomics.py
@@ -23,9 +23,9 @@ class Drug(BaseModel):
         description="Drug name as mentioned at source.", examples=["succinylcholine"]
     )
     drugId: Optional[str] = Field(
-        description="CHEMBL ID of the drug..",
-        examples=["CHEBI_45652"],
-        regex=r"^CHEBI_\d+$",
+        description="CHEMBL ID of the drug.",
+        examples=["CHEMBL703"],
+        regex=r"^CHEMBL_\d+$",
     )
 
 

--- a/pydantic_models/pharmacogenomics.py
+++ b/pydantic_models/pharmacogenomics.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Extra, Field
 
 
-class phenotypeCategory(str, Enum):
+class PhenotypeCategory(str, Enum):
     """Accepted phenotype categories describing pharmacogenomic effect."""
 
     toxicity = "toxicity"
@@ -16,6 +16,17 @@ class phenotypeCategory(str, Enum):
     metabolism = ("metabolism/pk",)
     pd = "pd"
     other = "other"
+
+class Drug(BaseModel):
+    """A drug object."""
+    drugsFromSource: str = Field(
+        description="Drug name as mentioned at source.", examples=["succinylcholine"]
+    )
+    drugId: Optional[str] = Field(
+        description="CHEMBL ID of the drug..",
+        examples=["CHEBI_45652"],
+        regex=r"^CHEBI_\d+$",
+    )
 
 
 class EvidenceLevel(str, Enum):
@@ -94,12 +105,7 @@ class Pharmacogenomics(BaseModel):
     directionality: Optional[str] = Field(
         description="Allele directionality of the effect.", examples=["decreased function"],
     )
-    drugsFromSource: List[str] = Field(description="Drug names. May be multiple in case of a drug combination.", examples=[["succinylcholine"]])
-    drugId: Optional[str] = Field(
-        description="CHEMBL ID of the drug, extracted from the name or ChEBI.",
-        examples=["CHEBI_45652"],
-        regex=r"^CHEBI_\d+$",
-    )
+    drugs: List[Drug]
     pgxCategory: str = Field(
         description="Pharmacogenomics phenotype category.", examples=["toxicity"]
     )

--- a/pydantic_models/pharmacogenomics.py
+++ b/pydantic_models/pharmacogenomics.py
@@ -94,12 +94,7 @@ class Pharmacogenomics(BaseModel):
     directionality: Optional[str] = Field(
         description="Allele directionality of the effect.", examples=["decreased function"],
     )
-    drugFromSource: str = Field(description="Drug name.", examples=["succinylcholine"])
-    drugFromSourceId: Optional[str] = Field(
-        description="CHEBI ID of drug, mapped through OLS.",
-        examples=["CHEBI_45652"],
-        regex=r"^CHEBI_\d+$",
-    )
+    drugsFromSource: List[str] = Field(description="Drug names. May be multiple in case of a drug combination.", examples=[["succinylcholine"]])
     drugId: Optional[str] = Field(
         description="CHEMBL ID of the drug, extracted from the name or ChEBI.",
         examples=["CHEBI_45652"],
@@ -124,7 +119,7 @@ class Pharmacogenomics(BaseModel):
 
 
 def main() -> None:
-    with open("schemas/pharmacogenomics.json", "wt") as f:
+    with open("schemas/pharmacogenomics_2.json", "wt") as f:
         f.write(Pharmacogenomics.schema_json(indent=2))
         f.write('\n')
 

--- a/pydantic_models/pharmacogenomics.py
+++ b/pydantic_models/pharmacogenomics.py
@@ -119,7 +119,7 @@ class Pharmacogenomics(BaseModel):
 
 
 def main() -> None:
-    with open("schemas/pharmacogenomics_2.json", "wt") as f:
+    with open("schemas/pharmacogenomics.json", "wt") as f:
         f.write(Pharmacogenomics.schema_json(indent=2))
         f.write('\n')
 

--- a/schemas/pharmacogenomics.json
+++ b/schemas/pharmacogenomics.json
@@ -202,10 +202,10 @@
         },
         "drugId": {
           "title": "Drugid",
-          "description": "CHEMBL ID of the drug..",
-          "pattern": "^CHEBI_\\d+$",
+          "description": "CHEMBL ID of the drug.",
+          "pattern": "^CHEMBL_\\d+$",
           "examples": [
-            "CHEBI_45652"
+            "CHEMBL703"
           ],
           "type": "string"
         }

--- a/schemas/pharmacogenomics.json
+++ b/schemas/pharmacogenomics.json
@@ -129,22 +129,18 @@
       ],
       "type": "string"
     },
-    "drugFromSource": {
-      "title": "Drugfromsource",
-      "description": "Drug name.",
+    "drugsFromSource": {
+      "title": "Drugsfromsource",
+      "description": "Drug names. May be multiple in case of a drug combination.",
       "examples": [
-        "succinylcholine"
+        [
+          "succinylcholine"
+        ]
       ],
-      "type": "string"
-    },
-    "drugFromSourceId": {
-      "title": "Drugfromsourceid",
-      "description": "CHEBI ID of drug, mapped through OLS.",
-      "pattern": "^CHEBI_\\d+$",
-      "examples": [
-        "CHEBI_45652"
-      ],
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "drugId": {
       "title": "Drugid",
@@ -188,7 +184,7 @@
     "literature",
     "genotype",
     "genotypeAnnotationText",
-    "drugFromSource",
+    "drugsFromSource",
     "pgxCategory"
   ],
   "additionalProperties": false,

--- a/schemas/pharmacogenomics.json
+++ b/schemas/pharmacogenomics.json
@@ -129,27 +129,12 @@
       ],
       "type": "string"
     },
-    "drugsFromSource": {
-      "title": "Drugsfromsource",
-      "description": "Drug names. May be multiple in case of a drug combination.",
-      "examples": [
-        [
-          "succinylcholine"
-        ]
-      ],
+    "drugs": {
+      "title": "Drugs",
       "type": "array",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/Drug"
       }
-    },
-    "drugId": {
-      "title": "Drugid",
-      "description": "CHEMBL ID of the drug, extracted from the name or ChEBI.",
-      "pattern": "^CHEBI_\\d+$",
-      "examples": [
-        "CHEBI_45652"
-      ],
-      "type": "string"
     },
     "pgxCategory": {
       "title": "Pgxcategory",
@@ -184,7 +169,7 @@
     "literature",
     "genotype",
     "genotypeAnnotationText",
-    "drugsFromSource",
+    "drugs",
     "pgxCategory"
   ],
   "additionalProperties": false,
@@ -201,6 +186,33 @@
         "4"
       ],
       "type": "string"
+    },
+    "Drug": {
+      "title": "Drug",
+      "description": "A drug object.",
+      "type": "object",
+      "properties": {
+        "drugsFromSource": {
+          "title": "Drugsfromsource",
+          "description": "Drug name as mentioned at source.",
+          "examples": [
+            "succinylcholine"
+          ],
+          "type": "string"
+        },
+        "drugId": {
+          "title": "Drugid",
+          "description": "CHEMBL ID of the drug..",
+          "pattern": "^CHEBI_\\d+$",
+          "examples": [
+            "CHEBI_45652"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "drugsFromSource"
+      ]
     }
   }
 }


### PR DESCRIPTION
As accorded with EVA, we want to make the following changes to the PGX schema:
- Conversion of `drugFromSource` to the list `drugsFromSource`. This accommodates the possibility of distinguishing variants that vary several drugs in combination vs variants that affect multiple drugs independently. This change has downstream dependencies, will follow up in a separate ticket.
- Deletion of `drugFromSourceId`. The EVA team was extracting CHEBI IDs by querying ChEMBL based on the drug name. We follow a very similar approach when mapping to a ChEMBL ID. First, we use the drug name and if no match is found, we use ChEBIs. Since both approaches have the name as starting point, extracting ChEBIs is redundant. This change has downstream dependencies, will follow up in a separate ticket.

(obsolete)