### PR TITLE
fix(pgx): correct typo in `drugs`

### DIFF
--- a/schemas/pharmacogenomics.json
+++ b/schemas/pharmacogenomics.json
@@ -192,8 +192,8 @@
       "description": "A drug object.",
       "type": "object",
       "properties": {
-        "drugsFromSource": {
-          "title": "Drugsfromsource",
+        "drugFromSource": {
+          "title": "Drugfromsource",
           "description": "Drug name as mentioned at source.",
           "examples": [
             "succinylcholine"
@@ -211,7 +211,7 @@
         }
       },
       "required": [
-        "drugsFromSource"
+        "drugFromSource"
       ]
     }
   }


### PR DESCRIPTION
The `drugs.drugFromSource` field should be in singular, not plural. This PR fixes the typo