### PR TITLE
fix: change variant field to geneticVariation in disease_target_evide…

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1611,7 +1611,7 @@
       "type": "object",
       "description": "List of biomarkers.",
       "properties": {
-        "variant": {
+        "geneticVariation": {
           "type": "array",
           "items": {
             "type": "object",


### PR DESCRIPTION
Changing disease/target evidence schema of cancer biomarkers: renaming field `variant` to `geneticVariation`. 