### PR TITLE
fix: update assessment field type to array and field name to plural

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1525,11 +1525,15 @@
       "uniqueItems": true
     },
     "assessment": {
-      "type": "string",
-      "description": "Assessment of a study. In the context of Validation Lab, this is the assessment of the validation gene in a given cellular context.",
-      "examples": [
-        "Validated"
-      ]
+      "type": "array",
+      "description": "List of assessments of a study.",
+      "items": {
+        "type": "string",
+        "description": "Assessment of a study. In the context of Validation Lab, this is the assessment of the validation gene in a given cellular context.",
+        "examples": [
+          "Validated"
+        ]
+      }
     },
     "beta": {
       "type": "number",

--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1026,8 +1026,8 @@
         "assays": {
           "$ref": "#/definitions/assays"
         },
-        "assessment": {
-          "$ref": "#/definitions/assessment"
+        "assessments": {
+          "$ref": "#/definitions/assessments"
         }
       },
       "required": [
@@ -1524,7 +1524,7 @@
       },
       "uniqueItems": true
     },
-    "assessment": {
+    "assessments": {
       "type": "array",
       "description": "List of assessments of a study.",
       "items": {

--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1611,7 +1611,7 @@
       "type": "object",
       "description": "List of biomarkers.",
       "properties": {
-        "variant": {
+        "geneticVariation": {
           "type": "array",
           "items": {
             "type": "object",


### PR DESCRIPTION
Assessment field type was changed to `array` as the field now consists of a list of strings instead of a string. The field name `assessment` is now updated to the plural `assessments`.