### PR TITLE
feat(chembl): add `studyId` and `cohortPhenotypes`

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -115,6 +115,9 @@
         "clinicalStatus": {
           "$ref": "#/definitions/clinicalStatus"
         },
+        "cohortPhenotypes": {
+          "$ref": "#/definitions/cohortPhenotypes"
+        },
         "datatypeId": {
           "$ref": "#/definitions/datatypeId"
         },
@@ -126,6 +129,9 @@
         },
         "drugId": {
           "$ref": "#/definitions/drugId"
+        },
+        "studyId": {
+          "$ref": "#/definitions/studyId"
         },
         "studyStartDate": {
           "$ref": "#/definitions/studyStartDate"


### PR DESCRIPTION
This PR adds 2 additional fields to the ChEMBL evidence to accommodate changes we have requested:
- `studyId`: will contain the NCT ID every time the source comes from clinicaltrials.gov. This ID was already present inside `urls`, but had to be parsed. It is just for data completion. Context here https://github.com/chembl/chembl_data/issues/810

- `cohortPhenotypes`: solves this issue https://github.com/opentargets/issues/issues/3328