### PR TITLE
chore(essentiality): give support to CL identifiers

### DIFF
--- a/pydantic_models/essentiality.py
+++ b/pydantic_models/essentiality.py
@@ -28,7 +28,7 @@ class Screens(BaseModel):
     __root__: List[Screen] = Field(unique=True)
 
 class DepMapEssentiality(BaseModel):
-    tissueId: Optional[str] = Field(description="Uberon tissue identifier.", examples=['UBERON_0004535'], regex=r'UBERON_\d+')
+    tissueId: Optional[str] = Field(description="Tissue identifier.", examples=['UBERON_0004535', 'CL_0000057'], regex=r'(^UBERON_\\d+$|^CL_\\d+$)')
     tissueName: str = Field(description='Tissue name', examples=['liver'])
     screens: Screens
 

--- a/pydantic_models/essentiality.py
+++ b/pydantic_models/essentiality.py
@@ -28,7 +28,7 @@ class Screens(BaseModel):
     __root__: List[Screen] = Field(unique=True)
 
 class DepMapEssentiality(BaseModel):
-    tissueId: Optional[str] = Field(description="Tissue identifier.", examples=['UBERON_0004535', 'CL_0000057'], regex=r'(^UBERON_\\d+$|^CL_\\d+$)')
+    tissueId: Optional[str] = Field(description="Tissue identifier.", examples=['UBERON_0004535', 'CL_0000057'], regex=r'(^UBERON_\d+$|^CL_\d+$)')
     tissueName: str = Field(description='Tissue name', examples=['liver'])
     screens: Screens
 

--- a/schemas/gene-essentiality.json
+++ b/schemas/gene-essentiality.json
@@ -113,10 +113,11 @@
       "properties": {
         "tissueId": {
           "title": "Tissueid",
-          "description": "Uberon tissue identifier.",
-          "pattern": "UBERON_\\d+",
+          "description": "Tissue identifier.",
+          "pattern": "(^UBERON_\\d+$|^CL_\\d+$)",
           "examples": [
-            "UBERON_0004535"
+            "UBERON_0004535",
+            "CL_0000057"
           ],
           "type": "string"
         },


### PR DESCRIPTION
Data from the DepMap 2024Q4 update uses CL identifiers. We need to make this change in order for the data to be valid.