### PR TITLE
feat: extending evidence schema to allow storing timestamps or literature references

### DIFF
--- a/schemas/disease_target_evidence.json
+++ b/schemas/disease_target_evidence.json
@@ -1314,6 +1314,9 @@
         "targetFromSourceId": {
           "$ref": "#/definitions/targetFromSourceId"
         },
+        "literature": {
+           "$ref": "#/definitions/literature"
+        },
         "diseaseFromSourceMappedId": {
           "$ref": "#/definitions/diseaseFromSourceMappedId"
         }


### PR DESCRIPTION
## Context

As part of the evidence timestamping effort, evidence schemas need to be extended with either literature or date references.

- SLAPenrich: literature